### PR TITLE
feat(cmd): implement Linear issue ROB-229 - Add root command with AI News Agent output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,13 +7,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "ai-news-agent-cli",
-	Short: "AI-powered news aggregation CLI",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("ai-news-agent-cli -- help with `-h`")
-	},
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ai-news-agent-cli",
+		Short: "AI-powered news aggregation CLI",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintln(cmd.OutOrStdout(), "AI News Agent")
+		},
+	}
+	return cmd
 }
+
+var rootCmd = NewRootCmd()
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootCmd(t *testing.T) {
+	cmd := NewRootCmd()
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "AI News Agent")
+}


### PR DESCRIPTION
## Summary

Implements Linear issue ROB-229 by adding a root command that prints 'AI News Agent' when executed.

## Changes Made

- **Updated :**
  - Modified the Run function to print "AI News Agent" using fmt.Fprintln
  - Added NewRootCmd() function for better testability
  - Kept existing Execute() function with proper error handling

- **Created :**
  - Implemented TestRootCmd function as specified
  - Test executes root command and captures stdout
  - Asserts output contains "AI News Agent"
  - Verifies command executes without errors

## Testing

- ✅ Unit tests pass: ok  	github.com/robertguss/ai-news-agent-cli/cmd	(cached)
- ✅ All tests pass: ?   	github.com/robertguss/ai-news-agent-cli	[no test files]
ok  	github.com/robertguss/ai-news-agent-cli/cmd	(cached)
ok  	github.com/robertguss/ai-news-agent-cli/internal/health	(cached)
- ✅ CLI works: AI News Agent outputs "AI News Agent"
- ✅ Help works: AI-powered news aggregation CLI

Usage:
  ai-news-agent-cli [flags]

Flags:
  -h, --help   help for ai-news-agent-cli shows proper description
- ✅ Code formatted and vetted

## Definition of Done

All requirements from ROB-229 have been met:
- Root command prints "AI News Agent" when executed
- Proper Cobra command structure
- Unit tests implemented and passing
- Execute function properly exported and callable