### PR TITLE
Implement view command for ROB-231

### DIFF
--- a/cmd/view.go
+++ b/cmd/view.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+        "context"
+        "database/sql"
+        "fmt"
+
+        "github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/spf13/cobra"
+)
+
+var databaseOpen = database.Open
+
+var viewCmd = &cobra.Command{
+        Use:   "view",
+        Short: "List articles stored in the database",
+        RunE: func(cmd *cobra.Command, args []string) error {
+                dbPath, _ := cmd.Flags().GetString("db")
+                
+                db, q, err := databaseOpen(dbPath)
+                if err != nil {
+                        return err
+                }
+                defer db.Close()
+                
+                err = database.InitSchema(db)
+                if err != nil {
+                        return err
+                }
+                
+                ctx := context.Background()
+                articles, err := q.ListArticles(ctx)
+                if err != nil {
+                        return err
+                }
+                
+                if len(articles) == 0 {
+                        fmt.Fprintln(cmd.OutOrStdout(), "No articles found.")
+                        return nil
+                }
+                
+                for _, article := range articles {
+                        title := formatNullString(article.Title, "(no title)")
+                        source := formatNullString(article.SourceName, "(no source)")
+                        fmt.Fprintf(cmd.OutOrStdout(), "%s - %s\n", title, source)
+                }
+                
+                return nil
+        },
+}
+
+func formatNullString(ns sql.NullString, placeholder string) string {
+        if ns.Valid && ns.String != "" {
+                return ns.String
+        }
+        return placeholder
+}
+
+func init() {
+        viewCmd.Flags().StringP("db", "d", "news.db", "Database file path")
+        rootCmd.AddCommand(viewCmd)
+}

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+        "bytes"
+        "context"
+        "database/sql"
+        "os"
+        "path/filepath"
+        "testing"
+
+        "github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
+)
+
+func setupTestDB(t *testing.T) (*sql.DB, func()) {
+        db, err := sql.Open("sqlite", ":memory:")
+        require.NoError(t, err)
+        
+        err = database.InitSchema(db)
+        require.NoError(t, err)
+        
+        return db, func() {
+                db.Close()
+        }
+}
+
+func insertTestArticle(db *sql.DB, title, sourceName string) {
+        var titleVal, sourceVal sql.NullString
+        
+        if title != "" {
+                titleVal = sql.NullString{String: title, Valid: true}
+        }
+        if sourceName != "" {
+                sourceVal = sql.NullString{String: sourceName, Valid: true}
+        }
+        
+        q := database.New(db)
+        _, err := q.CreateArticle(context.Background(), database.CreateArticleParams{
+                Title:      titleVal,
+                SourceName: sourceVal,
+        })
+        if err != nil {
+                panic(err)
+        }
+}
+
+func executeViewCommand(args ...string) (string, error) {
+        cmd := NewRootCmd()
+        cmd.AddCommand(viewCmd)
+        
+        var buf bytes.Buffer
+        cmd.SetOut(&buf)
+        cmd.SetErr(&buf)
+        cmd.SetArgs(args)
+        
+        err := cmd.Execute()
+        return buf.String(), err
+}
+
+func TestViewCmd_EmptyDatabase(t *testing.T) {
+        db, cleanup := setupTestDB(t)
+        defer cleanup()
+        
+        originalOpen := databaseOpen
+        databaseOpen = func(dataSource string) (*sql.DB, *database.Queries, error) {
+                return db, database.New(db), nil
+        }
+        defer func() { databaseOpen = originalOpen }()
+        
+        output, err := executeViewCommand("view")
+        
+        assert.NoError(t, err)
+        assert.Equal(t, "No articles found.\n", output)
+}
+
+func TestViewCmd_SingleArticle(t *testing.T) {
+        db, cleanup := setupTestDB(t)
+        defer cleanup()
+        
+        insertTestArticle(db, "Test Title", "Test Source")
+        
+        originalOpen := databaseOpen
+        databaseOpen = func(dataSource string) (*sql.DB, *database.Queries, error) {
+                return db, database.New(db), nil
+        }
+        defer func() { databaseOpen = originalOpen }()
+        
+        output, err := executeViewCommand("view")
+        
+        assert.NoError(t, err)
+        assert.Equal(t, "Test Title - Test Source\n", output)
+}
+
+func TestViewCmd_MultipleArticles(t *testing.T) {
+        db, cleanup := setupTestDB(t)
+        defer cleanup()
+        
+        insertTestArticle(db, "First Article", "BBC")
+        insertTestArticle(db, "Second Article", "Reuters")
+        insertTestArticle(db, "Third Article", "CNN")
+        
+        originalOpen := databaseOpen
+        databaseOpen = func(dataSource string) (*sql.DB, *database.Queries, error) {
+                return db, database.New(db), nil
+        }
+        defer func() { databaseOpen = originalOpen }()
+        
+        output, err := executeViewCommand("view")
+        
+        assert.NoError(t, err)
+        expected := "First Article - BBC\nSecond Article - Reuters\nThird Article - CNN\n"
+        assert.Equal(t, expected, output)
+}
+
+func TestViewCmd_NullValues(t *testing.T) {
+        db, cleanup := setupTestDB(t)
+        defer cleanup()
+        
+        insertTestArticle(db, "", "Test Source")
+        insertTestArticle(db, "Test Title", "")
+        insertTestArticle(db, "", "")
+        
+        originalOpen := databaseOpen
+        databaseOpen = func(dataSource string) (*sql.DB, *database.Queries, error) {
+                return db, database.New(db), nil
+        }
+        defer func() { databaseOpen = originalOpen }()
+        
+        output, err := executeViewCommand("view")
+        
+        assert.NoError(t, err)
+        expected := "(no title) - Test Source\nTest Title - (no source)\n(no title) - (no source)\n"
+        assert.Equal(t, expected, output)
+}
+
+func TestViewCmd_DatabaseFlag(t *testing.T) {
+        tmpDir := t.TempDir()
+        dbPath := filepath.Join(tmpDir, "test.db")
+        
+        db, err := sql.Open("sqlite", dbPath)
+        require.NoError(t, err)
+        defer db.Close()
+        
+        err = database.InitSchema(db)
+        require.NoError(t, err)
+        
+        insertTestArticle(db, "Flag Test", "Test Source")
+        
+        output, err := executeViewCommand("view", "--db", dbPath)
+        
+        assert.NoError(t, err)
+        assert.Equal(t, "Flag Test - Test Source\n", output)
+}
+
+func TestViewCmd_DatabaseConnectionError(t *testing.T) {
+        output, err := executeViewCommand("view", "--db", "/invalid/path/db.sqlite")
+        
+        assert.Error(t, err)
+        assert.Contains(t, output, "Error:")
+}
+
+func TestViewCmd_DatabaseAutoCreation(t *testing.T) {
+        tmpDir := t.TempDir()
+        dbPath := filepath.Join(tmpDir, "new_test.db")
+        
+        _, err := os.Stat(dbPath)
+        assert.True(t, os.IsNotExist(err))
+        
+        output, err := executeViewCommand("view", "--db", dbPath)
+        
+        assert.NoError(t, err)
+        assert.Equal(t, "No articles found.\n", output)
+        
+        _, err = os.Stat(dbPath)
+        assert.NoError(t, err)
+}
+
+func TestViewCmd_Integration(t *testing.T) {
+        tmpDir := t.TempDir()
+        dbPath := filepath.Join(tmpDir, "integration.db")
+        
+        db, err := sql.Open("sqlite", dbPath)
+        require.NoError(t, err)
+        
+        err = database.InitSchema(db)
+        require.NoError(t, err)
+        
+        insertTestArticle(db, "Integration Test", "Integration Source")
+        db.Close()
+        
+        output, err := executeViewCommand("view", "--db", dbPath)
+        
+        assert.NoError(t, err)
+        assert.Equal(t, "Integration Test - Integration Source\n", output)
+}


### PR DESCRIPTION
Implements the view command functionality for Linear issue ROB-231. Added ai-news view command with configurable database path, auto-creates database with proper schema, displays articles in Title - SourceName format, handles null values with placeholders, and includes comprehensive test suite. Closes ROB-231