### PR TITLE
Implement ROB-235: Content Scraping Module using TDD

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1,0 +1,74 @@
+package scraper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+var (
+	ErrInvalidURL = errors.New("scraper: invalid url")
+)
+
+type ErrStatus struct {
+	Code int
+}
+
+func (e ErrStatus) Error() string {
+	return "scraper: http status " + strconv.Itoa(e.Code)
+}
+
+var HTTPClient = &http.Client{
+	Timeout: 0,
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).DialContext,
+		ResponseHeaderTimeout: 60 * time.Second,
+	},
+}
+
+func Scrape(rawURL string) (string, error) {
+	u, err := url.ParseRequestURI(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", ErrInvalidURL
+	}
+
+	jinaURL := buildJinaURL(u)
+	
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jinaURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "text/markdown")
+
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", ErrStatus{Code: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 5<<20))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func buildJinaURL(u *url.URL) string {
+	return fmt.Sprintf("https://r.jina.ai/%s", u.String())
+}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1,0 +1,210 @@
+package scraper
+
+import (
+        "io"
+        "net"
+        "net/http"
+        "net/url"
+        "strings"
+        "testing"
+        "time"
+
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
+)
+
+type mockRoundTripper struct {
+        handler func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+        return m.handler(req)
+}
+
+func TestScrape(t *testing.T) {
+        t.Run("happy path - returns markdown content", func(t *testing.T) {
+                expectedMarkdown := "# Test Article\n\nThis is test content from Jina Reader."
+                
+                originalClient := HTTPClient
+                HTTPClient = &http.Client{
+                        Transport: &mockRoundTripper{
+                                handler: func(req *http.Request) (*http.Response, error) {
+                                        assert.Equal(t, "GET", req.Method)
+                                        assert.Equal(t, "text/markdown", req.Header.Get("Accept"))
+                                        assert.Equal(t, "https://r.jina.ai/https://example.com/article", req.URL.String())
+                                        
+                                        return &http.Response{
+                                                StatusCode: http.StatusOK,
+                                                Body:       io.NopCloser(strings.NewReader(expectedMarkdown)),
+                                                Header:     make(http.Header),
+                                        }, nil
+                                },
+                        },
+                }
+                defer func() { HTTPClient = originalClient }()
+
+                result, err := Scrape("https://example.com/article")
+                
+                require.NoError(t, err)
+                assert.Equal(t, expectedMarkdown, result)
+        })
+
+        t.Run("invalid URL format", func(t *testing.T) {
+                testCases := []string{
+                        ":::",
+                        "not-a-url",
+                        "ftp://example.com",
+                        "",
+                        "javascript:alert('xss')",
+                }
+
+                for _, invalidURL := range testCases {
+                        t.Run(invalidURL, func(t *testing.T) {
+                                result, err := Scrape(invalidURL)
+                                
+                                assert.Empty(t, result)
+                                assert.ErrorIs(t, err, ErrInvalidURL)
+                        })
+                }
+        })
+
+        t.Run("HTTP error status codes", func(t *testing.T) {
+                testCases := []struct {
+                        statusCode int
+                        name       string
+                }{
+                        {http.StatusNotFound, "404 Not Found"},
+                        {http.StatusInternalServerError, "500 Internal Server Error"},
+                        {http.StatusBadRequest, "400 Bad Request"},
+                        {http.StatusForbidden, "403 Forbidden"},
+                }
+
+                for _, tc := range testCases {
+                        t.Run(tc.name, func(t *testing.T) {
+                                originalClient := HTTPClient
+                                HTTPClient = &http.Client{
+                                        Transport: &mockRoundTripper{
+                                                handler: func(req *http.Request) (*http.Response, error) {
+                                                        return &http.Response{
+                                                                StatusCode: tc.statusCode,
+                                                                Body:       io.NopCloser(strings.NewReader("")),
+                                                                Header:     make(http.Header),
+                                                        }, nil
+                                                },
+                                        },
+                                }
+                                defer func() { HTTPClient = originalClient }()
+
+                                result, err := Scrape("https://example.com/article")
+                                
+                                assert.Empty(t, result)
+                                require.Error(t, err)
+                                
+                                var statusErr ErrStatus
+                                assert.ErrorAs(t, err, &statusErr)
+                                assert.Equal(t, tc.statusCode, statusErr.Code)
+                        })
+                }
+        })
+
+        t.Run("network error", func(t *testing.T) {
+                originalClient := HTTPClient
+                HTTPClient = &http.Client{
+                        Transport: &mockRoundTripper{
+                                handler: func(req *http.Request) (*http.Response, error) {
+                                        return nil, &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Name: "nonexistent.invalid"}}
+                                },
+                        },
+                }
+                defer func() { HTTPClient = originalClient }()
+
+                result, err := Scrape("https://nonexistent.invalid/article")
+                
+                assert.Empty(t, result)
+                assert.Error(t, err)
+                assert.NotErrorIs(t, err, ErrInvalidURL)
+        })
+
+        t.Run("request timeout", func(t *testing.T) {
+                originalClient := HTTPClient
+                HTTPClient = &http.Client{
+                        Timeout: 100 * time.Millisecond,
+                        Transport: &mockRoundTripper{
+                                handler: func(req *http.Request) (*http.Response, error) {
+                                        select {
+                                        case <-req.Context().Done():
+                                                return nil, req.Context().Err()
+                                        case <-time.After(200 * time.Millisecond):
+                                                return &http.Response{
+                                                        StatusCode: http.StatusOK,
+                                                        Body:       io.NopCloser(strings.NewReader("too slow")),
+                                                        Header:     make(http.Header),
+                                                }, nil
+                                        }
+                                },
+                        },
+                }
+                defer func() { HTTPClient = originalClient }()
+
+                result, err := Scrape("https://example.com/article")
+                
+                assert.Empty(t, result)
+                assert.Error(t, err)
+                assert.Contains(t, err.Error(), "deadline exceeded")
+        })
+
+        t.Run("empty response body", func(t *testing.T) {
+                originalClient := HTTPClient
+                HTTPClient = &http.Client{
+                        Transport: &mockRoundTripper{
+                                handler: func(req *http.Request) (*http.Response, error) {
+                                        return &http.Response{
+                                                StatusCode: http.StatusOK,
+                                                Body:       io.NopCloser(strings.NewReader("")),
+                                                Header:     make(http.Header),
+                                        }, nil
+                                },
+                        },
+                }
+                defer func() { HTTPClient = originalClient }()
+
+                result, err := Scrape("https://example.com/article")
+                
+                require.NoError(t, err)
+                assert.Empty(t, result)
+        })
+}
+
+func TestBuildJinaURL(t *testing.T) {
+        testCases := []struct {
+                input    string
+                expected string
+                name     string
+        }{
+                {
+                        input:    "https://example.com/article",
+                        expected: "https://r.jina.ai/https://example.com/article",
+                        name:     "HTTPS URL",
+                },
+                {
+                        input:    "http://example.com/article",
+                        expected: "https://r.jina.ai/http://example.com/article",
+                        name:     "HTTP URL",
+                },
+                {
+                        input:    "https://example.com/path/to/article?param=value",
+                        expected: "https://r.jina.ai/https://example.com/path/to/article?param=value",
+                        name:     "URL with path and query",
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        u, err := url.ParseRequestURI(tc.input)
+                        require.NoError(t, err)
+                        
+                        result := buildJinaURL(u)
+                        assert.Equal(t, tc.expected, result)
+                })
+        }
+}


### PR DESCRIPTION
- Create internal/scraper package with Scrape(url string) (string, error) function
- Use Jina Reader API (https://r.jina.ai/{url}) for content extraction
- Return markdown content suitable for AI processing
- HTTP client with 30s connection timeout, 60s read timeout
- Comprehensive error handling for network, HTTP status, invalid URLs
- 5MB response size limit for safety
- Full test coverage using TDD approach with mock RoundTripper
- Tests cover happy path, error cases, timeouts, and edge cases