### PR TITLE
Implement ROB-236: Integrate mock AI processor with fetch command

### DIFF
--- a/internal/fetcher/ai_integration_test.go
+++ b/internal/fetcher/ai_integration_test.go
@@ -1,0 +1,167 @@
+package fetcher
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/robertguss/ai-news-agent-cli/internal/ai/processor"
+	"github.com/robertguss/ai-news-agent-cli/internal/ai/processor/mocks"
+	"github.com/robertguss/ai-news-agent-cli/internal/database"
+	"github.com/robertguss/ai-news-agent-cli/internal/scraper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func TestStoreArticlesWithAI_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = database.InitSchema(db)
+	require.NoError(t, err)
+
+	queries := database.New(db)
+
+	mockScraper := scraper.NewMockScraper("scraped article content", nil)
+	mockAI := new(mocks.AIProcessor)
+	mockAI.On("AnalyzeContent", "scraped article content").Return(&processor.AnalysisResult{
+		Summary: "AI generated summary",
+	}, nil)
+
+	deps := PipelineDeps{
+		Scraper: mockScraper,
+		AI:      mockAI,
+		Queries: queries,
+	}
+
+	articles := []Article{
+		{
+			Title:         "Test Article",
+			Link:          "https://example.com/test",
+			PublishedDate: time.Now(),
+		},
+	}
+
+	source := Source{
+		Name: "Test Source",
+	}
+
+	ctx := context.Background()
+	stored, err := StoreArticlesWithAI(ctx, deps, articles, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stored)
+
+	var summary sql.NullString
+	err = db.QueryRow("SELECT summary FROM articles WHERE url = ?", "https://example.com/test").Scan(&summary)
+	require.NoError(t, err)
+	assert.True(t, summary.Valid)
+	assert.Equal(t, "AI generated summary", summary.String)
+
+	mockAI.AssertExpectations(t)
+}
+
+func TestStoreArticlesWithAI_ScraperError(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = database.InitSchema(db)
+	require.NoError(t, err)
+
+	queries := database.New(db)
+
+	mockScraper := scraper.NewMockScraper("", assert.AnError)
+	mockAI := new(mocks.AIProcessor)
+
+	deps := PipelineDeps{
+		Scraper: mockScraper,
+		AI:      mockAI,
+		Queries: queries,
+	}
+
+	articles := []Article{
+		{
+			Title:         "Test Article",
+			Link:          "https://example.com/test",
+			PublishedDate: time.Now(),
+		},
+	}
+
+	source := Source{
+		Name: "Test Source",
+	}
+
+	ctx := context.Background()
+	stored, err := StoreArticlesWithAI(ctx, deps, articles, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stored)
+
+	var summary sql.NullString
+	err = db.QueryRow("SELECT summary FROM articles WHERE url = ?", "https://example.com/test").Scan(&summary)
+	require.NoError(t, err)
+	assert.False(t, summary.Valid)
+
+	mockAI.AssertNotCalled(t, "AnalyzeContent", mock.Anything)
+}
+
+func TestStoreArticlesWithAI_AIError(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = database.InitSchema(db)
+	require.NoError(t, err)
+
+	queries := database.New(db)
+
+	mockScraper := scraper.NewMockScraper("scraped content", nil)
+	mockAI := new(mocks.AIProcessor)
+	mockAI.On("AnalyzeContent", "scraped content").Return(nil, assert.AnError)
+
+	deps := PipelineDeps{
+		Scraper: mockScraper,
+		AI:      mockAI,
+		Queries: queries,
+	}
+
+	articles := []Article{
+		{
+			Title:         "Test Article",
+			Link:          "https://example.com/test",
+			PublishedDate: time.Now(),
+		},
+	}
+
+	source := Source{
+		Name: "Test Source",
+	}
+
+	ctx := context.Background()
+	stored, err := StoreArticlesWithAI(ctx, deps, articles, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stored)
+
+	var summary sql.NullString
+	err = db.QueryRow("SELECT summary FROM articles WHERE url = ?", "https://example.com/test").Scan(&summary)
+	require.NoError(t, err)
+	assert.False(t, summary.Valid)
+
+	mockAI.AssertExpectations(t)
+}

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -1,117 +1,206 @@
 package fetcher
 
 import (
-	"context"
-	"database/sql"
-	"time"
+        "context"
+        "database/sql"
+        "time"
 
-	"github.com/mmcdole/gofeed"
-	"github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/mmcdole/gofeed"
+        "github.com/robertguss/ai-news-agent-cli/internal/ai/processor"
+        "github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/robertguss/ai-news-agent-cli/internal/scraper"
 )
 
 type Source struct {
-	Name     string `mapstructure:"name"`
-	URL      string `mapstructure:"url"`
-	Type     string `mapstructure:"type"`
-	Priority int    `mapstructure:"priority"`
+        Name     string `mapstructure:"name"`
+        URL      string `mapstructure:"url"`
+        Type     string `mapstructure:"type"`
+        Priority int    `mapstructure:"priority"`
 }
 
 type Article struct {
-	Title         string
-	Link          string
-	PublishedDate time.Time
+        Title         string
+        Link          string
+        PublishedDate time.Time
+}
+
+type PipelineDeps struct {
+        Scraper scraper.Scraper
+        AI      processor.AIProcessor
+        Queries *database.Queries
 }
 
 func Fetch(ctx context.Context, source Source) ([]Article, error) {
-	parser := gofeed.NewParser()
-	feed, err := parser.ParseURLWithContext(source.URL, ctx)
-	if err != nil {
-		return nil, err
-	}
+        parser := gofeed.NewParser()
+        feed, err := parser.ParseURLWithContext(source.URL, ctx)
+        if err != nil {
+                return nil, err
+        }
 
-	var articles []Article
-	for _, item := range feed.Items {
-		publishedDate := time.Now()
-		if item.PublishedParsed != nil {
-			publishedDate = *item.PublishedParsed
-		}
+        var articles []Article
+        for _, item := range feed.Items {
+                publishedDate := time.Now()
+                if item.PublishedParsed != nil {
+                        publishedDate = *item.PublishedParsed
+                }
 
-		article := Article{
-			Title:         item.Title,
-			Link:          item.Link,
-			PublishedDate: publishedDate,
-		}
-		articles = append(articles, article)
-	}
+                article := Article{
+                        Title:         item.Title,
+                        Link:          item.Link,
+                        PublishedDate: publishedDate,
+                }
+                articles = append(articles, article)
+        }
 
-	return articles, nil
+        return articles, nil
 }
 
 func StoreArticles(ctx context.Context, queries *database.Queries, articles []Article, source Source) (int, error) {
-	stored := 0
+        stored := 0
 
-	for _, article := range articles {
-		_, err := queries.GetArticleByUrl(ctx, sql.NullString{
-			String: article.Link,
-			Valid:  true,
-		})
+        for _, article := range articles {
+                _, err := queries.GetArticleByUrl(ctx, sql.NullString{
+                        String: article.Link,
+                        Valid:  true,
+                })
 
-		if err == sql.ErrNoRows {
-			params := database.CreateArticleParams{
-				Title: sql.NullString{
-					String: article.Title,
-					Valid:  true,
-				},
-				Url: sql.NullString{
-					String: article.Link,
-					Valid:  true,
-				},
-				SourceName: sql.NullString{
-					String: source.Name,
-					Valid:  true,
-				},
-				PublishedDate: sql.NullTime{
-					Time:  article.PublishedDate,
-					Valid: true,
-				},
-				Summary: sql.NullString{
-					String: "",
-					Valid:  false,
-				},
-				Entities: nil,
-				ContentType: sql.NullString{
-					String: "",
-					Valid:  false,
-				},
-				Topics: nil,
-				Status: sql.NullString{
-					String: "unread",
-					Valid:  true,
-				},
-				StoryGroupID: sql.NullString{
-					String: "",
-					Valid:  false,
-				},
-			}
+                if err == sql.ErrNoRows {
+                        params := database.CreateArticleParams{
+                                Title: sql.NullString{
+                                        String: article.Title,
+                                        Valid:  true,
+                                },
+                                Url: sql.NullString{
+                                        String: article.Link,
+                                        Valid:  true,
+                                },
+                                SourceName: sql.NullString{
+                                        String: source.Name,
+                                        Valid:  true,
+                                },
+                                PublishedDate: sql.NullTime{
+                                        Time:  article.PublishedDate,
+                                        Valid: true,
+                                },
+                                Summary: sql.NullString{
+                                        String: "",
+                                        Valid:  false,
+                                },
+                                Entities: nil,
+                                ContentType: sql.NullString{
+                                        String: "",
+                                        Valid:  false,
+                                },
+                                Topics: nil,
+                                Status: sql.NullString{
+                                        String: "unread",
+                                        Valid:  true,
+                                },
+                                StoryGroupID: sql.NullString{
+                                        String: "",
+                                        Valid:  false,
+                                },
+                        }
 
-			_, err = queries.CreateArticle(ctx, params)
-			if err != nil {
-				return stored, err
-			}
-			stored++
-		} else if err != nil {
-			return stored, err
-		}
-	}
+                        _, err = queries.CreateArticle(ctx, params)
+                        if err != nil {
+                                return stored, err
+                        }
+                        stored++
+                } else if err != nil {
+                        return stored, err
+                }
+        }
 
-	return stored, nil
+        return stored, nil
 }
 
 func FetchAndStore(ctx context.Context, queries *database.Queries, source Source) (int, error) {
-	articles, err := Fetch(ctx, source)
-	if err != nil {
-		return 0, err
-	}
+        articles, err := Fetch(ctx, source)
+        if err != nil {
+                return 0, err
+        }
 
-	return StoreArticles(ctx, queries, articles, source)
+        return StoreArticles(ctx, queries, articles, source)
+}
+
+func FetchAndStoreWithAI(ctx context.Context, deps PipelineDeps, source Source) (int, error) {
+        articles, err := Fetch(ctx, source)
+        if err != nil {
+                return 0, err
+        }
+
+        return StoreArticlesWithAI(ctx, deps, articles, source)
+}
+
+func StoreArticlesWithAI(ctx context.Context, deps PipelineDeps, articles []Article, source Source) (int, error) {
+        stored := 0
+
+        for _, article := range articles {
+                _, err := deps.Queries.GetArticleByUrl(ctx, sql.NullString{
+                        String: article.Link,
+                        Valid:  true,
+                })
+
+                if err == sql.ErrNoRows {
+                        var summary sql.NullString
+                        
+                        if deps.Scraper != nil && deps.AI != nil {
+                                content, scrapeErr := deps.Scraper.Scrape(article.Link)
+                                if scrapeErr == nil {
+                                        result, aiErr := deps.AI.AnalyzeContent(content)
+                                        if aiErr == nil && result != nil {
+                                                summary = sql.NullString{
+                                                        String: result.Summary,
+                                                        Valid:  true,
+                                                }
+                                        }
+                                }
+                        }
+
+                        params := database.CreateArticleParams{
+                                Title: sql.NullString{
+                                        String: article.Title,
+                                        Valid:  true,
+                                },
+                                Url: sql.NullString{
+                                        String: article.Link,
+                                        Valid:  true,
+                                },
+                                SourceName: sql.NullString{
+                                        String: source.Name,
+                                        Valid:  true,
+                                },
+                                PublishedDate: sql.NullTime{
+                                        Time:  article.PublishedDate,
+                                        Valid: true,
+                                },
+                                Summary: summary,
+                                Entities: nil,
+                                ContentType: sql.NullString{
+                                        String: "",
+                                        Valid:  false,
+                                },
+                                Topics: nil,
+                                Status: sql.NullString{
+                                        String: "unread",
+                                        Valid:  true,
+                                },
+                                StoryGroupID: sql.NullString{
+                                        String: "",
+                                        Valid:  false,
+                                },
+                        }
+
+                        _, err = deps.Queries.CreateArticle(ctx, params)
+                        if err != nil {
+                                return stored, err
+                        }
+                        stored++
+                } else if err != nil {
+                        return stored, err
+                }
+        }
+
+        return stored, nil
 }

--- a/internal/scraper/interface.go
+++ b/internal/scraper/interface.go
@@ -1,0 +1,15 @@
+package scraper
+
+type Scraper interface {
+	Scrape(url string) (string, error)
+}
+
+type JinaScraper struct{}
+
+func (j *JinaScraper) Scrape(url string) (string, error) {
+	return Scrape(url)
+}
+
+func NewJinaScraper() *JinaScraper {
+	return &JinaScraper{}
+}

--- a/internal/scraper/mock.go
+++ b/internal/scraper/mock.go
@@ -1,0 +1,17 @@
+package scraper
+
+type MockScraper struct {
+	content string
+	err     error
+}
+
+func NewMockScraper(content string, err error) *MockScraper {
+	return &MockScraper{
+		content: content,
+		err:     err,
+	}
+}
+
+func (m *MockScraper) Scrape(url string) (string, error) {
+	return m.content, m.err
+}


### PR DESCRIPTION
- Add --use-mock-ai flag to fetch command
- Create scraper interface and mock implementation for testing
- Implement FetchAndStoreWithAI function with AI pipeline integration
- Add comprehensive tests for AI integration (integration and unit tests)
- Mock AI processor returns 'mock summary' as specified in requirements
- Error handling: skip articles that fail scraping or AI processing
- All tests passing, ready for real AI implementation