### PR TITLE
Fix all lint errors

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,222 +1,214 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"runtime"
+        "context"
+        "fmt"
+        "runtime"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/robertguss/ai-news-agent-cli/internal/ai/processor"
-	"github.com/robertguss/ai-news-agent-cli/internal/ai/processor/mocks"
-	"github.com/robertguss/ai-news-agent-cli/internal/config"
-	"github.com/robertguss/ai-news-agent-cli/internal/database"
-	"github.com/robertguss/ai-news-agent-cli/internal/fetcher"
-	"github.com/robertguss/ai-news-agent-cli/internal/scraper"
-	"github.com/robertguss/ai-news-agent-cli/internal/tui"
-	"github.com/robertguss/ai-news-agent-cli/internal/tui/fetchui"
-	"github.com/robertguss/ai-news-agent-cli/pkg/errs"
-	"github.com/robertguss/ai-news-agent-cli/pkg/logging"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/mock"
+        tea "github.com/charmbracelet/bubbletea"
+        "github.com/robertguss/ai-news-agent-cli/internal/ai/processor"
+        "github.com/robertguss/ai-news-agent-cli/internal/ai/processor/mocks"
+        "github.com/robertguss/ai-news-agent-cli/internal/config"
+        "github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/robertguss/ai-news-agent-cli/internal/fetcher"
+        "github.com/robertguss/ai-news-agent-cli/internal/scraper"
+        "github.com/robertguss/ai-news-agent-cli/internal/tui"
+        "github.com/robertguss/ai-news-agent-cli/internal/tui/fetchui"
+        "github.com/robertguss/ai-news-agent-cli/pkg/errs"
+        "github.com/robertguss/ai-news-agent-cli/pkg/logging"
+        "github.com/spf13/cobra"
+        "github.com/stretchr/testify/mock"
 )
 
 var (
-	openDB   = database.Open
-	loadCfg  = config.LoadFromPath
-	fetchAnd = fetcher.FetchAndStore
-	initDB   = database.InitSchema
+        openDB  = database.Open
+        loadCfg = config.LoadFromPath
+        initDB  = database.InitSchema
 )
 
 var fetchCmd = &cobra.Command{
-	Use:   "fetch",
-	Short: "Fetch articles from configured sources and store them",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+        Use:   "fetch",
+        Short: "Fetch articles from configured sources and store them",
+        RunE: func(cmd *cobra.Command, args []string) error {
+                ctx := context.Background()
 
-		configPath, _ := cmd.Flags().GetString("config")
-		useMockAI, _ := cmd.Flags().GetBool("use-mock-ai")
-		plain, _ := cmd.Flags().GetBool("plain")
-		workers, _ := cmd.Flags().GetInt("workers")
-		limit, _ := cmd.Flags().GetInt("limit")
+                configPath, _ := cmd.Flags().GetString("config")
+                useMockAI, _ := cmd.Flags().GetBool("use-mock-ai")
+                plain, _ := cmd.Flags().GetBool("plain")
+                workers, _ := cmd.Flags().GetInt("workers")
+                limit, _ := cmd.Flags().GetInt("limit")
 
-		cfg, err := loadCfg(configPath)
-		if err != nil {
-			return fmt.Errorf("%s", errs.GetUserFriendlyMessage(errs.Wrap("load config", err)))
-		}
+                cfg, err := loadCfg(configPath)
+                if err != nil {
+                        return fmt.Errorf("%s", errs.GetUserFriendlyMessage(errs.Wrap("load config", err)))
+                }
 
-		if err := logging.Init(cfg.LogFile); err != nil {
-			return fmt.Errorf("failed to initialize logging: %w", err)
-		}
+                if err := logging.Init(cfg.LogFile); err != nil {
+                        return fmt.Errorf("failed to initialize logging: %w", err)
+                }
 
-		db, queries, err := openDB(cfg.DSN)
-		if err != nil {
-			return fmt.Errorf("%s", errs.GetUserFriendlyMessage(err))
-		}
-		defer db.Close()
+                db, queries, err := openDB(cfg.DSN)
+                if err != nil {
+                        return fmt.Errorf("%s", errs.GetUserFriendlyMessage(err))
+                }
+                defer db.Close()
 
-		if err := initDB(db); err != nil {
-			return fmt.Errorf("%s", errs.GetUserFriendlyMessage(err))
-		}
+                if err := initDB(db); err != nil {
+                        return fmt.Errorf("%s", errs.GetUserFriendlyMessage(err))
+                }
 
-		var aiProcessor processor.AIProcessor
+                var aiProcessor processor.AIProcessor
 
-		if useMockAI {
-			mockProcessor := new(mocks.AIProcessor)
-			mockProcessor.On("AnalyzeContent", mock.Anything).Return(&processor.AnalysisResult{
-				Summary: "mock summary",
-			}, nil)
-			mockProcessor.On("AnalyzeContentWithRetry", mock.Anything, mock.Anything, mock.Anything).Return(&processor.AnalysisResult{
-				Summary: "mock summary with retry",
-			}, nil)
-			aiProcessor = mockProcessor
-		} else {
-			var err error
-			aiProcessor, err = processor.NewGeminiProcessor(ctx)
-			if err != nil {
-				return fmt.Errorf("%s", errs.GetUserFriendlyMessage(errs.Wrap("initialize AI processor", err)))
-			}
-		}
+                if useMockAI {
+                        mockProcessor := new(mocks.AIProcessor)
+                        mockProcessor.On("AnalyzeContent", mock.Anything).Return(&processor.AnalysisResult{
+                                Summary: "mock summary",
+                        }, nil)
+                        mockProcessor.On("AnalyzeContentWithRetry", mock.Anything, mock.Anything, mock.Anything).Return(&processor.AnalysisResult{
+                                Summary: "mock summary with retry",
+                        }, nil)
+                        aiProcessor = mockProcessor
+                } else {
+                        var err error
+                        aiProcessor, err = processor.NewGeminiProcessor(ctx)
+                        if err != nil {
+                                return fmt.Errorf("%s", errs.GetUserFriendlyMessage(errs.Wrap("initialize AI processor", err)))
+                        }
+                }
 
-		opts := fetcher.FetchOptions{Limit: limit}
+                opts := fetcher.FetchOptions{Limit: limit}
 
-		if !plain && tui.ShouldUseTUI() {
-			return runInteractiveFetch(ctx, cfg, queries, aiProcessor, workers, opts)
-		}
+                if !plain && tui.ShouldUseTUI() {
+                        return runInteractiveFetch(ctx, cfg, queries, aiProcessor, workers, opts)
+                }
 
-		return runPlainFetch(ctx, cmd, cfg, queries, aiProcessor, opts)
-	},
+                return runPlainFetch(ctx, cmd, cfg, queries, aiProcessor, opts)
+        },
 }
 
 func runInteractiveFetch(ctx context.Context, cfg *config.Config, queries *database.Queries, aiProcessor processor.AIProcessor, workers int, opts fetcher.FetchOptions) error {
-	if workers <= 0 {
-		workers = runtime.NumCPU()
-	}
+        if workers <= 0 {
+                workers = runtime.NumCPU()
+        }
 
-	sourceNames := make([]string, len(cfg.Sources))
-	for i, source := range cfg.Sources {
-		sourceNames[i] = source.Name
-	}
+        sourceNames := make([]string, len(cfg.Sources))
+        for i, source := range cfg.Sources {
+                sourceNames[i] = source.Name
+        }
 
-	model := fetchui.New(sourceNames)
-	model.SetWorkerCount(workers)
+        model := fetchui.New(sourceNames)
+        model.SetWorkerCount(workers)
 
-	program := tea.NewProgram(model, tea.WithAltScreen())
+        program := tea.NewProgram(model, tea.WithAltScreen())
 
-	progress := make(chan tui.ArticleProgressMsg, 100)
+        progress := make(chan tui.ArticleProgressMsg, 100)
 
-	go func() {
-		for msg := range progress {
-			program.Send(msg)
-		}
-	}()
+        go func() {
+                for msg := range progress {
+                        program.Send(msg)
+                }
+        }()
 
-	go func() {
-		defer close(progress)
+        go func() {
+                defer close(progress)
 
-		var totalAdded int
-		var errors []error
-		successCount := 0
-		errorCount := 0
+                var totalAdded int
+                var errors []error
+                successCount := 0
+                errorCount := 0
 
-		processSource := func(ctx context.Context, source fetcher.Source, opts fetcher.FetchOptions, progressCh chan<- tui.DetailedProgressMsg) (int, error) {
-			deps := fetcher.PipelineDeps{
-				Scraper: scraper.NewJinaScraper(),
-				AI:      aiProcessor,
-				Queries: queries,
-				Config:  cfg,
-			}
+                processSource := func(ctx context.Context, source fetcher.Source, opts fetcher.FetchOptions, progressCh chan<- tui.DetailedProgressMsg) (int, error) {
+                        deps := fetcher.PipelineDeps{
+                                Scraper: scraper.NewJinaScraper(),
+                                AI:      aiProcessor,
+                                Queries: queries,
+                                Config:  cfg,
+                        }
 
-			return fetcher.FetchAndStoreWithAIProgress(ctx, deps, source, opts, progressCh)
-		}
+                        return fetcher.FetchAndStoreWithAIProgress(ctx, deps, source, opts, progressCh)
+                }
 
-		detailedProgress := make(chan tui.DetailedProgressMsg, 100)
+                detailedProgress := make(chan tui.DetailedProgressMsg, 100)
 
-		go func() {
-			for msg := range detailedProgress {
-				progress <- tui.ArticleProgressMsg{
-					Source:       msg.Source,
-					Phase:        msg.Phase,
-					Current:      msg.Current,
-					Total:        msg.Total,
-					ArticleTitle: msg.ArticleTitle,
-					Error:        msg.Error,
-				}
-			}
-		}()
+                go func() {
+                        for msg := range detailedProgress {
+                                progress <- tui.ArticleProgressMsg(msg)
+                        }
+                }()
 
-		results := fetcher.ProcessSourcesConcurrently(ctx, cfg.Sources, workers, processSource, opts, detailedProgress)
-		close(detailedProgress)
+                results := fetcher.ProcessSourcesConcurrently(ctx, cfg.Sources, workers, processSource, opts, detailedProgress)
+                close(detailedProgress)
 
-		for _, result := range results {
-			if result.Error != nil {
-				errorCount++
-				errors = append(errors, fmt.Errorf("source %s: %w", result.Source.Name, result.Error))
-				program.Send(tui.CompletedMsg{
-					Source: result.Source.Name,
-					Error:  result.Error,
-				})
-			} else {
-				successCount++
-				totalAdded += result.Added
-				program.Send(tui.CompletedMsg{
-					Source: result.Source.Name,
-					Added:  result.Added,
-				})
-			}
-		}
+                for _, result := range results {
+                        if result.Error != nil {
+                                errorCount++
+                                errors = append(errors, fmt.Errorf("source %s: %w", result.Source.Name, result.Error))
+                                program.Send(tui.CompletedMsg{
+                                        Source: result.Source.Name,
+                                        Error:  result.Error,
+                                })
+                        } else {
+                                successCount++
+                                totalAdded += result.Added
+                                program.Send(tui.CompletedMsg{
+                                        Source: result.Source.Name,
+                                        Added:  result.Added,
+                                })
+                        }
+                }
 
-		program.Send(tui.FinalSummaryMsg{
-			TotalAdded:   totalAdded,
-			TotalSources: len(cfg.Sources),
-			SuccessCount: successCount,
-			ErrorCount:   errorCount,
-			Errors:       errors,
-		})
-	}()
+                program.Send(tui.FinalSummaryMsg{
+                        TotalAdded:   totalAdded,
+                        TotalSources: len(cfg.Sources),
+                        SuccessCount: successCount,
+                        ErrorCount:   errorCount,
+                        Errors:       errors,
+                })
+        }()
 
-	_, err := program.Run()
-	return err
+        _, err := program.Run()
+        return err
 }
 
 func runPlainFetch(ctx context.Context, cmd *cobra.Command, cfg *config.Config, queries *database.Queries, aiProcessor processor.AIProcessor, opts fetcher.FetchOptions) error {
-	var added int
-	var errors []error
+        var added int
+        var errors []error
 
-	for _, source := range cfg.Sources {
-		deps := fetcher.PipelineDeps{
-			Scraper: scraper.NewJinaScraper(),
-			AI:      aiProcessor,
-			Queries: queries,
-			Config:  cfg,
-		}
+        for _, source := range cfg.Sources {
+                deps := fetcher.PipelineDeps{
+                        Scraper: scraper.NewJinaScraper(),
+                        AI:      aiProcessor,
+                        Queries: queries,
+                        Config:  cfg,
+                }
 
-		n, err := fetcher.FetchAndStoreWithAI(ctx, deps, source, opts)
-		if err != nil {
-			userFriendlyErr := errs.GetUserFriendlyMessage(err)
-			errors = append(errors, fmt.Errorf("source %s: %s", source.Name, userFriendlyErr))
-			continue
-		}
-		added += n
-	}
+                n, err := fetcher.FetchAndStoreWithAI(ctx, deps, source, opts)
+                if err != nil {
+                        userFriendlyErr := errs.GetUserFriendlyMessage(err)
+                        errors = append(errors, fmt.Errorf("source %s: %s", source.Name, userFriendlyErr))
+                        continue
+                }
+                added += n
+        }
 
-	if len(errors) > 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "Added %d new articles from %d sources\n", added, len(cfg.Sources))
-		fmt.Fprintf(cmd.OutOrStdout(), "%d errors occurred:\n", len(errors))
-		for _, err := range errors {
-			fmt.Fprintf(cmd.OutOrStdout(), "  - %v\n", err)
-		}
-	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "Added %d new articles from %d sources\n", added, len(cfg.Sources))
-	}
+        if len(errors) > 0 {
+                fmt.Fprintf(cmd.OutOrStdout(), "Added %d new articles from %d sources\n", added, len(cfg.Sources))
+                fmt.Fprintf(cmd.OutOrStdout(), "%d errors occurred:\n", len(errors))
+                for _, err := range errors {
+                        fmt.Fprintf(cmd.OutOrStdout(), "  - %v\n", err)
+                }
+        } else {
+                fmt.Fprintf(cmd.OutOrStdout(), "Added %d new articles from %d sources\n", added, len(cfg.Sources))
+        }
 
-	return nil
+        return nil
 }
 
 func init() {
-	fetchCmd.Flags().StringP("config", "c", "", "Path to config file")
-	fetchCmd.Flags().Bool("use-mock-ai", false, "Use mock AI processor for testing")
-	fetchCmd.Flags().Bool("plain", false, "Use plain text output instead of interactive TUI")
-	fetchCmd.Flags().IntP("workers", "w", 0, "Number of worker goroutines (0 = auto-detect based on CPU cores)")
-	fetchCmd.Flags().IntP("limit", "n", 5, "Maximum number of articles to fetch per source (0 = unlimited)")
-	rootCmd.AddCommand(fetchCmd)
+        fetchCmd.Flags().StringP("config", "c", "", "Path to config file")
+        fetchCmd.Flags().Bool("use-mock-ai", false, "Use mock AI processor for testing")
+        fetchCmd.Flags().Bool("plain", false, "Use plain text output instead of interactive TUI")
+        fetchCmd.Flags().IntP("workers", "w", 0, "Number of worker goroutines (0 = auto-detect based on CPU cores)")
+        fetchCmd.Flags().IntP("limit", "n", 5, "Maximum number of articles to fetch per source (0 = unlimited)")
+        rootCmd.AddCommand(fetchCmd)
 }

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -39,7 +39,7 @@ func TestFetchCmd_Integration_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
+		_, _ = w.Write([]byte(rssContent))
 	}))
 	defer server.Close()
 
@@ -138,7 +138,7 @@ func TestFetchCmd_Integration_PartialSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
+		_, _ = w.Write([]byte(rssContent))
 	}))
 	defer server.Close()
 
@@ -203,7 +203,7 @@ func TestFetchCmd_Integration_WithMockAI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
+		_, _ = w.Write([]byte(rssContent))
 	}))
 	defer server.Close()
 
@@ -300,7 +300,7 @@ func TestFetchCmd_ContinuesOnPartialAIFailures(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
+		_, _ = w.Write([]byte(rssContent))
 	}))
 	defer server.Close()
 

--- a/cmd/read_test.go
+++ b/cmd/read_test.go
@@ -95,7 +95,7 @@ func TestReadCommandSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "https://example.com/article")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("# Test Article\n\nThis is test content."))
+		_, _ = w.Write([]byte("# Test Article\n\nThis is test content."))
 	}))
 	defer server.Close()
 
@@ -135,7 +135,7 @@ func TestReadCommandWithCache(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("# Cached Article\n\nThis is cached content."))
+		_, _ = w.Write([]byte("# Cached Article\n\nThis is cached content."))
 	}))
 	defer server.Close()
 
@@ -176,7 +176,7 @@ func TestReadCommandNoCache(t *testing.T) {
 		requestCount++
 		assert.Contains(t, r.URL.RawQuery, "no-cache=true")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("# Fresh Article\n\nThis is fresh content."))
+		_, _ = w.Write([]byte("# Fresh Article\n\nThis is fresh content."))
 	}))
 	defer server.Close()
 
@@ -214,7 +214,7 @@ func TestReadCommandNoCache(t *testing.T) {
 func TestReadCommandHTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("Not Found"))
+		_, _ = w.Write([]byte("Not Found"))
 	}))
 	defer server.Close()
 
@@ -281,7 +281,7 @@ func TestGetArticleContent(t *testing.T) {
 	t.Run("fetches fresh content when cache is old", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("fresh content"))
+			_, _ = w.Write([]byte("fresh content"))
 		}))
 		defer server.Close()
 
@@ -303,7 +303,7 @@ func TestGetArticleContent(t *testing.T) {
 	t.Run("forces fresh fetch with no-cache", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("forced fresh content"))
+			_, _ = w.Write([]byte("forced fresh content"))
 		}))
 		defer server.Close()
 

--- a/cmd/styles.go
+++ b/cmd/styles.go
@@ -1,86 +1,84 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
+        "fmt"
+        "strings"
 
-	"github.com/charmbracelet/lipgloss"
+        "github.com/charmbracelet/lipgloss"
 )
 
 var (
-	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#FFFFFF"))
+        titleStyle = lipgloss.NewStyle().
+                        Bold(true).
+                        Foreground(lipgloss.Color("#FFFFFF"))
 
-	sourceStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#7D7D7D"))
+        sourceStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#7D7D7D"))
 
-	summaryStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CCCCCC")).
-			MarginLeft(2)
+        summaryStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#CCCCCC")).
+                        MarginLeft(2)
 
-	topicsStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00D7FF")).
-			Italic(true)
+        topicsStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#00D7FF")).
+                        Italic(true)
 
-	cardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#874BFD")).
-			Padding(1, 2).
-			MarginBottom(1)
+        cardStyle = lipgloss.NewStyle().
+                        Border(lipgloss.RoundedBorder()).
+                        BorderForeground(lipgloss.Color("#874BFD")).
+                        Padding(1, 2).
+                        MarginBottom(1)
 
-	tierStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#00FF87"))
 
-	duplicatesStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFA500")).
-			MarginLeft(2)
+
+        duplicatesStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#FFA500")).
+                        MarginLeft(2)
 )
 
 func getSourceTier(sourceName string) int {
-	tierMap := map[string]int{
-		"Google AI Blog":  1,
-		"OpenAI Blog":     1,
-		"Ars Technica AI": 2,
-		"The Verge":       2,
-		"Ars Technica":    2,
-	}
+        tierMap := map[string]int{
+                "Google AI Blog":  1,
+                "OpenAI Blog":     1,
+                "Ars Technica AI": 2,
+                "The Verge":       2,
+                "Ars Technica":    2,
+        }
 
-	if tier, exists := tierMap[sourceName]; exists {
-		return tier
-	}
-	return 3
+        if tier, exists := tierMap[sourceName]; exists {
+                return tier
+        }
+        return 3
 }
 
 func formatCard(index int, title, sourceName, summary, topics string, duplicates []string) string {
-	tier := getSourceTier(sourceName)
+        tier := getSourceTier(sourceName)
 
-	var cardContent strings.Builder
+        var cardContent strings.Builder
 
-	cardContent.WriteString(fmt.Sprintf("[%d] %s\n", index, titleStyle.Render(title)))
+        cardContent.WriteString(fmt.Sprintf("[%d] %s\n", index, titleStyle.Render(title)))
 
-	sourceInfo := fmt.Sprintf("Source: %s (Tier %d)", sourceName, tier)
-	cardContent.WriteString(sourceStyle.Render(sourceInfo))
-	cardContent.WriteString("\n")
+        sourceInfo := fmt.Sprintf("Source: %s (Tier %d)", sourceName, tier)
+        cardContent.WriteString(sourceStyle.Render(sourceInfo))
+        cardContent.WriteString("\n")
 
-	if summary != "" {
-		cardContent.WriteString("Summary:\n")
-		bulletPoints := strings.Split(summary, ". ")
-		for _, point := range bulletPoints {
-			if strings.TrimSpace(point) != "" {
-				cardContent.WriteString(summaryStyle.Render(fmt.Sprintf("• %s\n", strings.TrimSpace(point))))
-			}
-		}
-	}
+        if summary != "" {
+                cardContent.WriteString("Summary:\n")
+                bulletPoints := strings.Split(summary, ". ")
+                for _, point := range bulletPoints {
+                        if strings.TrimSpace(point) != "" {
+                                cardContent.WriteString(summaryStyle.Render(fmt.Sprintf("• %s\n", strings.TrimSpace(point))))
+                        }
+                }
+        }
 
-	if topics != "" {
-		cardContent.WriteString(fmt.Sprintf("Topics: %s\n", topicsStyle.Render(topics)))
-	}
+        if topics != "" {
+                cardContent.WriteString(fmt.Sprintf("Topics: %s\n", topicsStyle.Render(topics)))
+        }
 
-	if len(duplicates) > 0 {
-		cardContent.WriteString(duplicatesStyle.Render(fmt.Sprintf("Also covered by: %s\n", strings.Join(duplicates, ", "))))
-	}
+        if len(duplicates) > 0 {
+                cardContent.WriteString(duplicatesStyle.Render(fmt.Sprintf("Also covered by: %s\n", strings.Join(duplicates, ", "))))
+        }
 
-	return cardStyle.Render(cardContent.String())
+        return cardStyle.Render(cardContent.String())
 }

--- a/internal/ai/processor/gemini_processor_test.go
+++ b/internal/ai/processor/gemini_processor_test.go
@@ -1,184 +1,181 @@
 package processor
 
 import (
-	"context"
-	"encoding/json"
-	"os"
-	"testing"
+        "context"
+        "encoding/json"
+        "os"
+        "testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestNewGeminiProcessor_Success(t *testing.T) {
-	originalKey := os.Getenv("GEMINI_API_KEY")
-	defer os.Setenv("GEMINI_API_KEY", originalKey)
+        originalKey := os.Getenv("GEMINI_API_KEY")
+        defer os.Setenv("GEMINI_API_KEY", originalKey)
 
-	os.Setenv("GEMINI_API_KEY", "test-api-key")
+        os.Setenv("GEMINI_API_KEY", "test-api-key")
 
-	processor, err := NewGeminiProcessor(context.Background())
-	require.NoError(t, err)
-	assert.NotNil(t, processor)
+        processor, err := NewGeminiProcessor(context.Background())
+        require.NoError(t, err)
+        assert.NotNil(t, processor)
 }
 
 func TestNewGeminiProcessor_MissingAPIKey(t *testing.T) {
-	originalKey := os.Getenv("GEMINI_API_KEY")
-	defer os.Setenv("GEMINI_API_KEY", originalKey)
+        originalKey := os.Getenv("GEMINI_API_KEY")
+        defer os.Setenv("GEMINI_API_KEY", originalKey)
 
-	os.Unsetenv("GEMINI_API_KEY")
+        os.Unsetenv("GEMINI_API_KEY")
 
-	processor, err := NewGeminiProcessor(context.Background())
-	assert.Error(t, err)
-	assert.Nil(t, processor)
-	assert.Contains(t, err.Error(), "GEMINI_API_KEY")
+        processor, err := NewGeminiProcessor(context.Background())
+        assert.Error(t, err)
+        assert.Nil(t, processor)
+        assert.Contains(t, err.Error(), "GEMINI_API_KEY")
 }
 
 func TestNewGeminiProcessor_EmptyAPIKey(t *testing.T) {
-	originalKey := os.Getenv("GEMINI_API_KEY")
-	defer os.Setenv("GEMINI_API_KEY", originalKey)
+        originalKey := os.Getenv("GEMINI_API_KEY")
+        defer os.Setenv("GEMINI_API_KEY", originalKey)
 
-	os.Setenv("GEMINI_API_KEY", "")
+        os.Setenv("GEMINI_API_KEY", "")
 
-	processor, err := NewGeminiProcessor(context.Background())
-	assert.Error(t, err)
-	assert.Nil(t, processor)
-	assert.Contains(t, err.Error(), "GEMINI_API_KEY")
+        processor, err := NewGeminiProcessor(context.Background())
+        assert.Error(t, err)
+        assert.Nil(t, processor)
+        assert.Contains(t, err.Error(), "GEMINI_API_KEY")
 }
 
 func TestGeminiProcessor_AnalyzeContent_Success(t *testing.T) {
-	originalKey := os.Getenv("GEMINI_API_KEY")
-	defer os.Setenv("GEMINI_API_KEY", originalKey)
+        originalKey := os.Getenv("GEMINI_API_KEY")
+        defer os.Setenv("GEMINI_API_KEY", originalKey)
 
-	os.Setenv("GEMINI_API_KEY", "test-api-key")
+        os.Setenv("GEMINI_API_KEY", "test-api-key")
 
-	processor, err := NewGeminiProcessor(context.Background())
-	require.NoError(t, err)
-	require.NotNil(t, processor)
+        processor, err := NewGeminiProcessor(context.Background())
+        require.NoError(t, err)
+        require.NotNil(t, processor)
 
-	content := "OpenAI has released a new GPT model with significant improvements."
+        content := "OpenAI has released a new GPT model with significant improvements."
 
-	result, err := processor.AnalyzeContent(content)
+        result, err := processor.AnalyzeContent(content)
 
-	if err != nil {
-		t.Skipf("Skipping integration test - requires real API key: %v", err)
-		return
-	}
+        if err != nil {
+                t.Skipf("Skipping integration test - requires real API key: %v", err)
+                return
+        }
 
-	require.NotNil(t, result)
-	assert.NotEmpty(t, result.Summary)
-	assert.NotEmpty(t, result.ContentType)
-	assert.NotEmpty(t, result.StoryGroupID)
+        require.NotNil(t, result)
+        assert.NotEmpty(t, result.Summary)
+        assert.NotEmpty(t, result.ContentType)
+        assert.NotEmpty(t, result.StoryGroupID)
 }
 
 func TestGeminiProcessor_AnalyzeContent_NetworkError(t *testing.T) {
-	originalKey := os.Getenv("GEMINI_API_KEY")
-	defer os.Setenv("GEMINI_API_KEY", originalKey)
+        originalKey := os.Getenv("GEMINI_API_KEY")
+        defer os.Setenv("GEMINI_API_KEY", originalKey)
 
-	os.Setenv("GEMINI_API_KEY", "invalid-key")
+        os.Setenv("GEMINI_API_KEY", "invalid-key")
 
-	processor, err := NewGeminiProcessor(context.Background())
-	require.NoError(t, err)
+        processor, err := NewGeminiProcessor(context.Background())
+        require.NoError(t, err)
 
-	result, err := processor.AnalyzeContent("test content")
-	assert.Error(t, err)
-	assert.Nil(t, result)
+        result, err := processor.AnalyzeContent("test content")
+        assert.Error(t, err)
+        assert.Nil(t, result)
 }
 
 func TestGeminiProcessor_AnalyzeContent_InvalidJSON(t *testing.T) {
-	t.Skip("Skipping JSON parsing test - requires proper HTTP mocking")
+        t.Skip("Skipping JSON parsing test - requires proper HTTP mocking")
 }
 
 func TestGeminiProcessor_AnalyzeContent_HTTPError(t *testing.T) {
-	t.Skip("Skipping HTTP error test - requires proper HTTP mocking")
+        t.Skip("Skipping HTTP error test - requires proper HTTP mocking")
 }
 
 func TestAnalysisResult_JSONSerialization(t *testing.T) {
-	result := AnalysisResult{
-		Summary: "Test summary with bullet points",
-		Entities: Entities{
-			Organizations: []string{"OpenAI", "Google"},
-			Products:      []string{"GPT-4", "Gemini"},
-			People:        []string{"Sam Altman", "Sundar Pichai"},
-		},
-		Topics:       []string{"AI", "Machine Learning"},
-		ContentType:  "News Article",
-		StoryGroupID: "test-story-123",
-	}
+        result := AnalysisResult{
+                Summary: "Test summary with bullet points",
+                Entities: Entities{
+                        Organizations: []string{"OpenAI", "Google"},
+                        Products:      []string{"GPT-4", "Gemini"},
+                        People:        []string{"Sam Altman", "Sundar Pichai"},
+                },
+                Topics:       []string{"AI", "Machine Learning"},
+                ContentType:  "News Article",
+                StoryGroupID: "test-story-123",
+        }
 
-	data, err := json.Marshal(result)
-	require.NoError(t, err)
+        data, err := json.Marshal(result)
+        require.NoError(t, err)
 
-	var unmarshaled AnalysisResult
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
+        var unmarshaled AnalysisResult
+        err = json.Unmarshal(data, &unmarshaled)
+        require.NoError(t, err)
 
-	assert.Equal(t, result.Summary, unmarshaled.Summary)
-	assert.Equal(t, result.Entities.Organizations, unmarshaled.Entities.Organizations)
-	assert.Equal(t, result.Entities.Products, unmarshaled.Entities.Products)
-	assert.Equal(t, result.Entities.People, unmarshaled.Entities.People)
-	assert.Equal(t, result.Topics, unmarshaled.Topics)
-	assert.Equal(t, result.ContentType, unmarshaled.ContentType)
-	assert.Equal(t, result.StoryGroupID, unmarshaled.StoryGroupID)
+        assert.Equal(t, result.Summary, unmarshaled.Summary)
+        assert.Equal(t, result.Entities.Organizations, unmarshaled.Entities.Organizations)
+        assert.Equal(t, result.Entities.Products, unmarshaled.Entities.Products)
+        assert.Equal(t, result.Entities.People, unmarshaled.Entities.People)
+        assert.Equal(t, result.Topics, unmarshaled.Topics)
+        assert.Equal(t, result.ContentType, unmarshaled.ContentType)
+        assert.Equal(t, result.StoryGroupID, unmarshaled.StoryGroupID)
 }
 
 func TestAnalysisResult_DatabaseCompatibility(t *testing.T) {
-	result := AnalysisResult{
-		Summary: "Database compatibility test",
-		Entities: Entities{
-			Organizations: []string{"Company1", "Company2"},
-			Products:      []string{"Product1"},
-			People:        []string{"Person1"},
-		},
-		Topics:       []string{"Topic1", "Topic2"},
-		ContentType:  "Research Paper",
-		StoryGroupID: "db-test-456",
-	}
+        result := AnalysisResult{
+                Summary: "Database compatibility test",
+                Entities: Entities{
+                        Organizations: []string{"Company1", "Company2"},
+                        Products:      []string{"Product1"},
+                        People:        []string{"Person1"},
+                },
+                Topics:       []string{"Topic1", "Topic2"},
+                ContentType:  "Research Paper",
+                StoryGroupID: "db-test-456",
+        }
 
-	entitiesJSON := result.EntitiesJSON()
-	topicsJSON := result.TopicsJSON()
+        entitiesJSON := result.EntitiesJSON()
+        topicsJSON := result.TopicsJSON()
 
-	assert.NotNil(t, entitiesJSON)
-	assert.NotNil(t, topicsJSON)
+        assert.NotNil(t, entitiesJSON)
+        assert.NotNil(t, topicsJSON)
 
-	var entities Entities
-	err := json.Unmarshal(entitiesJSON, &entities)
-	require.NoError(t, err)
-	assert.Equal(t, result.Entities, entities)
+        var entities Entities
+        err := json.Unmarshal(entitiesJSON, &entities)
+        require.NoError(t, err)
+        assert.Equal(t, result.Entities, entities)
 
-	var topics []string
-	err = json.Unmarshal(topicsJSON, &topics)
-	require.NoError(t, err)
-	assert.Equal(t, result.Topics, topics)
+        var topics []string
+        err = json.Unmarshal(topicsJSON, &topics)
+        require.NoError(t, err)
+        assert.Equal(t, result.Topics, topics)
 }
 
 func TestStoryGroupID_Deterministic(t *testing.T) {
-	content1 := "This is test content for hashing"
-	content2 := "This is test content for hashing"
-	content3 := "This is different content"
+        content1 := "This is test content for hashing"
+        content2 := "This is test content for hashing"
+        content3 := "This is different content"
 
-	id1 := generateStoryGroupID(content1)
-	id2 := generateStoryGroupID(content2)
-	id3 := generateStoryGroupID(content3)
+        id1 := generateStoryGroupID(content1)
+        id2 := generateStoryGroupID(content2)
+        id3 := generateStoryGroupID(content3)
 
-	assert.Equal(t, id1, id2, "Same content should produce same story group ID")
-	assert.NotEqual(t, id1, id3, "Different content should produce different story group ID")
-	assert.NotEmpty(t, id1)
-	assert.NotEmpty(t, id3)
+        assert.Equal(t, id1, id2, "Same content should produce same story group ID")
+        assert.NotEqual(t, id1, id3, "Different content should produce different story group ID")
+        assert.NotEmpty(t, id1)
+        assert.NotEmpty(t, id3)
 }
 
 func TestStoryGroupID_Format(t *testing.T) {
-	content := "Test content for ID format validation"
-	id := generateStoryGroupID(content)
+        content := "Test content for ID format validation"
+        id := generateStoryGroupID(content)
 
-	assert.NotEmpty(t, id)
-	assert.Regexp(t, "^[a-f0-9]+$", id, "Story group ID should be hexadecimal")
+        assert.NotEmpty(t, id)
+        assert.Regexp(t, "^[a-f0-9]+$", id, "Story group ID should be hexadecimal")
 }
 
 func TestGeminiProcessor_ImplementsInterface(t *testing.T) {
-	var processor AIProcessor = &GeminiProcessor{}
-	assert.NotNil(t, processor)
-
-	if processor != nil {
-		var _ func(string) (*AnalysisResult, error) = processor.AnalyzeContent
-	}
+        var processor AIProcessor = &GeminiProcessor{}
+        assert.NotNil(t, processor)
+        var _ func(string) (*AnalysisResult, error) = processor.AnalyzeContent
 }

--- a/internal/article/fetch_test.go
+++ b/internal/article/fetch_test.go
@@ -1,130 +1,130 @@
 package article
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+        "context"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestFetchArticle(t *testing.T) {
-	tests := []struct {
-		name            string
-		articleURL      string
-		noCache         bool
-		serverResponse  func(w http.ResponseWriter, r *http.Request)
-		expectedError   string
-		expectedContent string
-	}{
-		{
-			name:       "successful fetch",
-			articleURL: "https://example.com/article",
-			noCache:    false,
-			serverResponse: func(w http.ResponseWriter, r *http.Request) {
-				assert.Contains(t, r.URL.Path, "https://example.com/article")
-				assert.NotContains(t, r.URL.RawQuery, "no-cache=true")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("# Test Article\n\nThis is test content."))
-			},
-			expectedContent: "# Test Article\n\nThis is test content.",
-		},
-		{
-			name:       "successful fetch with no-cache",
-			articleURL: "https://example.com/fresh",
-			noCache:    true,
-			serverResponse: func(w http.ResponseWriter, r *http.Request) {
-				assert.Contains(t, r.URL.Path, "https://example.com/fresh")
-				assert.Contains(t, r.URL.RawQuery, "no-cache=true")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("Fresh content"))
-			},
-			expectedContent: "Fresh content",
-		},
-		{
-			name:       "HTTP error",
-			articleURL: "https://example.com/notfound",
-			noCache:    false,
-			serverResponse: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusNotFound)
-				w.Write([]byte("Not Found"))
-			},
-			expectedError: "jina reader API returned 404 Not Found",
-		},
-		{
-			name:       "empty response",
-			articleURL: "https://example.com/empty",
-			noCache:    false,
-			serverResponse: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(""))
-			},
-			expectedError: "received empty content from jina reader",
-		},
-	}
+        tests := []struct {
+                name            string
+                articleURL      string
+                noCache         bool
+                serverResponse  func(w http.ResponseWriter, r *http.Request)
+                expectedError   string
+                expectedContent string
+        }{
+                {
+                        name:       "successful fetch",
+                        articleURL: "https://example.com/article",
+                        noCache:    false,
+                        serverResponse: func(w http.ResponseWriter, r *http.Request) {
+                                assert.Contains(t, r.URL.Path, "https://example.com/article")
+                                assert.NotContains(t, r.URL.RawQuery, "no-cache=true")
+                                w.WriteHeader(http.StatusOK)
+                                _, _ = w.Write([]byte("# Test Article\n\nThis is test content."))
+                        },
+                        expectedContent: "# Test Article\n\nThis is test content.",
+                },
+                {
+                        name:       "successful fetch with no-cache",
+                        articleURL: "https://example.com/fresh",
+                        noCache:    true,
+                        serverResponse: func(w http.ResponseWriter, r *http.Request) {
+                                assert.Contains(t, r.URL.Path, "https://example.com/fresh")
+                                assert.Contains(t, r.URL.RawQuery, "no-cache=true")
+                                w.WriteHeader(http.StatusOK)
+                                _, _ = w.Write([]byte("Fresh content"))
+                        },
+                        expectedContent: "Fresh content",
+                },
+                {
+                        name:       "HTTP error",
+                        articleURL: "https://example.com/notfound",
+                        noCache:    false,
+                        serverResponse: func(w http.ResponseWriter, r *http.Request) {
+                                w.WriteHeader(http.StatusNotFound)
+                                _, _ = w.Write([]byte("Not Found"))
+                        },
+                        expectedError: "jina reader API returned 404 Not Found",
+                },
+                {
+                        name:       "empty response",
+                        articleURL: "https://example.com/empty",
+                        noCache:    false,
+                        serverResponse: func(w http.ResponseWriter, r *http.Request) {
+                                w.WriteHeader(http.StatusOK)
+                                _, _ = w.Write([]byte(""))
+                        },
+                        expectedError: "received empty content from jina reader",
+                },
+        }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
-			defer server.Close()
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        server := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
+                        defer server.Close()
 
-			originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
-			defer SetJinaEndpointForTesting(originalEndpoint)
+                        originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
+                        defer SetJinaEndpointForTesting(originalEndpoint)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
+                        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+                        defer cancel()
 
-			content, err := FetchArticle(ctx, tt.articleURL, tt.noCache)
+                        content, err := FetchArticle(ctx, tt.articleURL, tt.noCache)
 
-			if tt.expectedError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedError)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedContent, content)
-			}
-		})
-	}
+                        if tt.expectedError != "" {
+                                require.Error(t, err)
+                                assert.Contains(t, err.Error(), tt.expectedError)
+                        } else {
+                                require.NoError(t, err)
+                                assert.Equal(t, tt.expectedContent, content)
+                        }
+                })
+        }
 }
 
 func TestFetchArticleTimeout(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Too slow"))
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                time.Sleep(2 * time.Second)
+                w.WriteHeader(http.StatusOK)
+                _, _ = w.Write([]byte("Too slow"))
+        }))
+        defer server.Close()
 
-	originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
-	defer SetJinaEndpointForTesting(originalEndpoint)
+        originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
+        defer SetJinaEndpointForTesting(originalEndpoint)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+        ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+        defer cancel()
 
-	_, err := FetchArticle(ctx, "https://example.com/slow", false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to fetch content")
+        _, err := FetchArticle(ctx, "https://example.com/slow", false)
+        require.Error(t, err)
+        assert.Contains(t, err.Error(), "failed to fetch content")
 }
 
 func TestFetchArticleURLEncoding(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		t.Logf("Received path: %s", path)
-		assert.Contains(t, path, "example.com")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Encoded URL content"))
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                path := r.URL.Path
+                t.Logf("Received path: %s", path)
+                assert.Contains(t, path, "example.com")
+                w.WriteHeader(http.StatusOK)
+                _, _ = w.Write([]byte("Encoded URL content"))
+        }))
+        defer server.Close()
 
-	originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
-	defer SetJinaEndpointForTesting(originalEndpoint)
+        originalEndpoint := SetJinaEndpointForTesting(server.URL + "/%s")
+        defer SetJinaEndpointForTesting(originalEndpoint)
 
-	ctx := context.Background()
-	content, err := FetchArticle(ctx, "https://example.com/article?id=123&type=news", false)
+        ctx := context.Background()
+        content, err := FetchArticle(ctx, "https://example.com/article?id=123&type=news", false)
 
-	require.NoError(t, err)
-	assert.Equal(t, "Encoded URL content", content)
+        require.NoError(t, err)
+        assert.Equal(t, "Encoded URL content", content)
 }

--- a/internal/article/render_test.go
+++ b/internal/article/render_test.go
@@ -1,96 +1,96 @@
 package article
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
+        "bytes"
+        "os"
+        "os/exec"
+        "strings"
+        "testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestRenderMarkdown(t *testing.T) {
-	content := "# Test Article\n\nThis is **bold** text."
+        content := "# Test Article\n\nThis is **bold** text."
 
-	t.Run("plain text rendering", func(t *testing.T) {
-		var buf bytes.Buffer
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
+        t.Run("plain text rendering", func(t *testing.T) {
+                var buf bytes.Buffer
+                oldStdout := os.Stdout
+                r, w, _ := os.Pipe()
+                os.Stdout = w
 
-		err := RenderMarkdown(content, false, w)
-		require.NoError(t, err)
+                err := RenderMarkdown(content, false, w)
+                require.NoError(t, err)
 
-		w.Close()
-		os.Stdout = oldStdout
+                w.Close()
+                os.Stdout = oldStdout
 
-		buf.ReadFrom(r)
-		output := buf.String()
-		assert.Equal(t, content, output)
-	})
+                _, _ = buf.ReadFrom(r)
+                output := buf.String()
+                assert.Equal(t, content, output)
+        })
 
-	t.Run("styled rendering fallback to glamour", func(t *testing.T) {
-		var buf bytes.Buffer
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
+        t.Run("styled rendering fallback to glamour", func(t *testing.T) {
+                var buf bytes.Buffer
+                oldStdout := os.Stdout
+                r, w, _ := os.Pipe()
+                os.Stdout = w
 
-		err := RenderMarkdown(content, true, w)
-		require.NoError(t, err)
+                err := RenderMarkdown(content, true, w)
+                require.NoError(t, err)
 
-		w.Close()
-		os.Stdout = oldStdout
+                w.Close()
+                os.Stdout = oldStdout
 
-		buf.ReadFrom(r)
-		output := buf.String()
+                _, _ = buf.ReadFrom(r)
+                output := buf.String()
 
-		assert.NotEmpty(t, output)
-		assert.NotEqual(t, content, output)
-	})
+                assert.NotEmpty(t, output)
+                assert.NotEqual(t, content, output)
+        })
 }
 
 func TestTryGlowCLI(t *testing.T) {
-	content := "# Test\n\nContent"
+        content := "# Test\n\nContent"
 
-	t.Run("glow not available", func(t *testing.T) {
-		originalPath := os.Getenv("PATH")
-		os.Setenv("PATH", "")
-		defer os.Setenv("PATH", originalPath)
+        t.Run("glow not available", func(t *testing.T) {
+                originalPath := os.Getenv("PATH")
+                os.Setenv("PATH", "")
+                defer os.Setenv("PATH", originalPath)
 
-		err := tryGlowCLI(content, &bytes.Buffer{})
-		assert.Error(t, err)
-	})
+                err := tryGlowCLI(content, &bytes.Buffer{})
+                assert.Error(t, err)
+        })
 
-	t.Run("glow available", func(t *testing.T) {
-		if _, err := exec.LookPath("glow"); err != nil {
-			t.Skip("glow not available in PATH")
-		}
+        t.Run("glow available", func(t *testing.T) {
+                if _, err := exec.LookPath("glow"); err != nil {
+                        t.Skip("glow not available in PATH")
+                }
 
-		err := tryGlowCLI(content, &bytes.Buffer{})
-		assert.NoError(t, err)
-	})
+                err := tryGlowCLI(content, &bytes.Buffer{})
+                assert.NoError(t, err)
+        })
 }
 
 func TestRenderWithGlamour(t *testing.T) {
-	content := "# Test Article\n\nThis is **bold** text with [link](https://example.com)."
+        content := "# Test Article\n\nThis is **bold** text with [link](https://example.com)."
 
-	var buf bytes.Buffer
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+        var buf bytes.Buffer
+        oldStdout := os.Stdout
+        r, w, _ := os.Pipe()
+        os.Stdout = w
 
-	err := renderWithGlamour(content, w)
-	require.NoError(t, err)
+        err := renderWithGlamour(content, w)
+        require.NoError(t, err)
 
-	w.Close()
-	os.Stdout = oldStdout
+        w.Close()
+        os.Stdout = oldStdout
 
-	buf.ReadFrom(r)
-	output := buf.String()
+        _, _ = buf.ReadFrom(r)
+        output := buf.String()
 
-	assert.NotEmpty(t, output)
-	assert.NotEqual(t, content, output)
-	assert.Contains(t, strings.ToLower(output), "test article")
+        assert.NotEmpty(t, output)
+        assert.NotEqual(t, content, output)
+        assert.Contains(t, strings.ToLower(output), "test article")
 }

--- a/internal/config/config_configs_test.go
+++ b/internal/config/config_configs_test.go
@@ -1,45 +1,45 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+        "os"
+        "path/filepath"
+        "testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestLoad_FromConfigsDirectory(t *testing.T) {
-	tempDir := t.TempDir()
-	configsDir := filepath.Join(tempDir, "configs")
-	err := os.MkdirAll(configsDir, 0755)
-	require.NoError(t, err)
+        tempDir := t.TempDir()
+        configsDir := filepath.Join(tempDir, "configs")
+        err := os.MkdirAll(configsDir, 0755)
+        require.NoError(t, err)
 
-	configPath := filepath.Join(configsDir, "config.yaml")
+        configPath := filepath.Join(configsDir, "config.yaml")
 
-	configContent := `sources:
+        configContent := `sources:
   - name: "Configs Dir Source"
     url: "https://example.com/configs-feed.xml"
     type: "rss"
     priority: 3`
 
-	err = os.WriteFile(configPath, []byte(configContent), 0644)
-	require.NoError(t, err)
+        err = os.WriteFile(configPath, []byte(configContent), 0644)
+        require.NoError(t, err)
 
-	originalDir, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(originalDir)
+        originalDir, err := os.Getwd()
+        require.NoError(t, err)
+        defer func() { _ = os.Chdir(originalDir) }()
 
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+        err = os.Chdir(tempDir)
+        require.NoError(t, err)
 
-	config, err := Load()
-	require.NoError(t, err)
-	require.NotNil(t, config)
+        config, err := Load()
+        require.NoError(t, err)
+        require.NotNil(t, config)
 
-	assert.Len(t, config.Sources, 1)
-	assert.Equal(t, "Configs Dir Source", config.Sources[0].Name)
-	assert.Equal(t, "https://example.com/configs-feed.xml", config.Sources[0].URL)
-	assert.Equal(t, "rss", config.Sources[0].Type)
-	assert.Equal(t, 3, config.Sources[0].Priority)
+        assert.Len(t, config.Sources, 1)
+        assert.Equal(t, "Configs Dir Source", config.Sources[0].Name)
+        assert.Equal(t, "https://example.com/configs-feed.xml", config.Sources[0].URL)
+        assert.Equal(t, "rss", config.Sources[0].Type)
+        assert.Equal(t, 3, config.Sources[0].Priority)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,19 +1,19 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+        "os"
+        "path/filepath"
+        "testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestLoad_Success(t *testing.T) {
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "config.yaml")
+        tempDir := t.TempDir()
+        configPath := filepath.Join(tempDir, "config.yaml")
 
-	configContent := `sources:
+        configContent := `sources:
   - name: "Test Source"
     url: "https://example.com/feed.xml"
     type: "rss"
@@ -23,65 +23,65 @@ func TestLoad_Success(t *testing.T) {
     type: "rss"
     priority: 2`
 
-	err := os.WriteFile(configPath, []byte(configContent), 0644)
-	require.NoError(t, err)
+        err := os.WriteFile(configPath, []byte(configContent), 0644)
+        require.NoError(t, err)
 
-	originalDir, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(originalDir)
+        originalDir, err := os.Getwd()
+        require.NoError(t, err)
+        defer func() { _ = os.Chdir(originalDir) }()
 
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+        err = os.Chdir(tempDir)
+        require.NoError(t, err)
 
-	config, err := Load()
-	require.NoError(t, err)
-	require.NotNil(t, config)
+        config, err := Load()
+        require.NoError(t, err)
+        require.NotNil(t, config)
 
-	assert.Len(t, config.Sources, 2)
-	assert.Equal(t, "Test Source", config.Sources[0].Name)
-	assert.Equal(t, "https://example.com/feed.xml", config.Sources[0].URL)
-	assert.Equal(t, "rss", config.Sources[0].Type)
-	assert.Equal(t, 1, config.Sources[0].Priority)
-	assert.Equal(t, "Another Source", config.Sources[1].Name)
-	assert.Equal(t, 2, config.Sources[1].Priority)
+        assert.Len(t, config.Sources, 2)
+        assert.Equal(t, "Test Source", config.Sources[0].Name)
+        assert.Equal(t, "https://example.com/feed.xml", config.Sources[0].URL)
+        assert.Equal(t, "rss", config.Sources[0].Type)
+        assert.Equal(t, 1, config.Sources[0].Priority)
+        assert.Equal(t, "Another Source", config.Sources[1].Name)
+        assert.Equal(t, 2, config.Sources[1].Priority)
 }
 
 func TestLoad_MissingFile(t *testing.T) {
-	tempDir := t.TempDir()
+        tempDir := t.TempDir()
 
-	originalDir, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(originalDir)
+        originalDir, err := os.Getwd()
+        require.NoError(t, err)
+        defer func() { _ = os.Chdir(originalDir) }()
 
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+        err = os.Chdir(tempDir)
+        require.NoError(t, err)
 
-	config, err := Load()
-	assert.Error(t, err)
-	assert.Nil(t, config)
+        config, err := Load()
+        assert.Error(t, err)
+        assert.Nil(t, config)
 }
 
 func TestLoad_InvalidYAML(t *testing.T) {
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "config.yaml")
+        tempDir := t.TempDir()
+        configPath := filepath.Join(tempDir, "config.yaml")
 
-	invalidYAML := `sources:
+        invalidYAML := `sources:
   - name: "Test Source"
     url: "https://example.com/feed.xml"
     type: "rss"
     priority: invalid_number`
 
-	err := os.WriteFile(configPath, []byte(invalidYAML), 0644)
-	require.NoError(t, err)
+        err := os.WriteFile(configPath, []byte(invalidYAML), 0644)
+        require.NoError(t, err)
 
-	originalDir, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(originalDir)
+        originalDir, err := os.Getwd()
+        require.NoError(t, err)
+        defer func() { _ = os.Chdir(originalDir) }()
 
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+        err = os.Chdir(tempDir)
+        require.NoError(t, err)
 
-	config, err := Load()
-	assert.Error(t, err)
-	assert.Nil(t, config)
+        config, err := Load()
+        assert.Error(t, err)
+        assert.Nil(t, config)
 }

--- a/internal/fetcher/database_integration_test.go
+++ b/internal/fetcher/database_integration_test.go
@@ -1,134 +1,134 @@
 package fetcher
 
 import (
-	"context"
-	"database/sql"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+        "context"
+        "database/sql"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
 
-	"github.com/robertguss/ai-news-agent-cli/internal/database"
-	"github.com/robertguss/ai-news-agent-cli/internal/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
+        "github.com/robertguss/ai-news-agent-cli/internal/database"
+        "github.com/robertguss/ai-news-agent-cli/internal/testutil"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
+        _ "modernc.org/sqlite"
 )
 
 func TestStoreArticles_Success(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	require.NoError(t, err)
-	defer db.Close()
+        db, err := sql.Open("sqlite", ":memory:")
+        require.NoError(t, err)
+        defer db.Close()
 
-	err = createTestSchema(db)
-	require.NoError(t, err)
+        err = createTestSchema(db)
+        require.NoError(t, err)
 
-	queries := database.New(db)
+        queries := database.New(db)
 
-	articles := []Article{
-		{
-			Title:         "Test Article 1",
-			Link:          "https://example.com/article1",
-			PublishedDate: time.Now(),
-		},
-		{
-			Title:         "Test Article 2",
-			Link:          "https://example.com/article2",
-			PublishedDate: time.Now().Add(-1 * time.Hour),
-		},
-	}
+        articles := []Article{
+                {
+                        Title:         "Test Article 1",
+                        Link:          "https://example.com/article1",
+                        PublishedDate: time.Now(),
+                },
+                {
+                        Title:         "Test Article 2",
+                        Link:          "https://example.com/article2",
+                        PublishedDate: time.Now().Add(-1 * time.Hour),
+                },
+        }
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      "https://example.com/feed",
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      "https://example.com/feed",
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	cfg := testutil.TestConfig()
-	ctx := context.Background()
-	stored, err := StoreArticles(ctx, queries, articles, source, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, 2, stored)
+        cfg := testutil.TestConfig()
+        ctx := context.Background()
+        stored, err := StoreArticles(ctx, queries, articles, source, cfg)
+        require.NoError(t, err)
+        assert.Equal(t, 2, stored)
 
-	dbArticles, err := queries.ListArticles(ctx)
-	require.NoError(t, err)
-	assert.Len(t, dbArticles, 2)
+        dbArticles, err := queries.ListArticles(ctx)
+        require.NoError(t, err)
+        assert.Len(t, dbArticles, 2)
 
-	assert.Equal(t, "Test Article 1", dbArticles[0].Title.String)
-	assert.Equal(t, "https://example.com/article1", dbArticles[0].Url.String)
-	assert.Equal(t, "Test Source", dbArticles[0].SourceName.String)
-	assert.Equal(t, "unread", dbArticles[0].Status.String)
+        assert.Equal(t, "Test Article 1", dbArticles[0].Title.String)
+        assert.Equal(t, "https://example.com/article1", dbArticles[0].Url.String)
+        assert.Equal(t, "Test Source", dbArticles[0].SourceName.String)
+        assert.Equal(t, "unread", dbArticles[0].Status.String)
 }
 
 func TestStoreArticles_DuplicateHandling(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	require.NoError(t, err)
-	defer db.Close()
+        db, err := sql.Open("sqlite", ":memory:")
+        require.NoError(t, err)
+        defer db.Close()
 
-	err = createTestSchema(db)
-	require.NoError(t, err)
+        err = createTestSchema(db)
+        require.NoError(t, err)
 
-	queries := database.New(db)
+        queries := database.New(db)
 
-	articles := []Article{
-		{
-			Title:         "Duplicate Article",
-			Link:          "https://example.com/duplicate",
-			PublishedDate: time.Now(),
-		},
-	}
+        articles := []Article{
+                {
+                        Title:         "Duplicate Article",
+                        Link:          "https://example.com/duplicate",
+                        PublishedDate: time.Now(),
+                },
+        }
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      "https://example.com/feed",
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      "https://example.com/feed",
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	cfg := testutil.TestConfig()
-	ctx := context.Background()
+        cfg := testutil.TestConfig()
+        ctx := context.Background()
 
-	stored1, err := StoreArticles(ctx, queries, articles, source, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, 1, stored1)
+        stored1, err := StoreArticles(ctx, queries, articles, source, cfg)
+        require.NoError(t, err)
+        assert.Equal(t, 1, stored1)
 
-	stored2, err := StoreArticles(ctx, queries, articles, source, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, 0, stored2)
+        stored2, err := StoreArticles(ctx, queries, articles, source, cfg)
+        require.NoError(t, err)
+        assert.Equal(t, 0, stored2)
 
-	dbArticles, err := queries.ListArticles(ctx)
-	require.NoError(t, err)
-	assert.Len(t, dbArticles, 1)
+        dbArticles, err := queries.ListArticles(ctx)
+        require.NoError(t, err)
+        assert.Len(t, dbArticles, 1)
 }
 
 func TestStoreArticles_EmptyList(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	require.NoError(t, err)
-	defer db.Close()
+        db, err := sql.Open("sqlite", ":memory:")
+        require.NoError(t, err)
+        defer db.Close()
 
-	err = createTestSchema(db)
-	require.NoError(t, err)
+        err = createTestSchema(db)
+        require.NoError(t, err)
 
-	queries := database.New(db)
+        queries := database.New(db)
 
-	var articles []Article
-	source := Source{
-		Name:     "Test Source",
-		URL:      "https://example.com/feed",
-		Type:     "rss",
-		Priority: 1,
-	}
+        var articles []Article
+        source := Source{
+                Name:     "Test Source",
+                URL:      "https://example.com/feed",
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	cfg := testutil.TestConfig()
-	ctx := context.Background()
-	stored, err := StoreArticles(ctx, queries, articles, source, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, 0, stored)
+        cfg := testutil.TestConfig()
+        ctx := context.Background()
+        stored, err := StoreArticles(ctx, queries, articles, source, cfg)
+        require.NoError(t, err)
+        assert.Equal(t, 0, stored)
 }
 
 func TestFetchAndStore_Integration(t *testing.T) {
-	rssContent := `<?xml version="1.0" encoding="UTF-8"?>
+        rssContent := `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
     <channel>
         <title>Test Feed</title>
@@ -140,45 +140,45 @@ func TestFetchAndStore_Integration(t *testing.T) {
     </channel>
 </rss>`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/rss+xml")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "application/rss+xml")
+                w.WriteHeader(http.StatusOK)
+                _, _ = w.Write([]byte(rssContent))
+        }))
+        defer server.Close()
 
-	db, err := sql.Open("sqlite", ":memory:")
-	require.NoError(t, err)
-	defer db.Close()
+        db, err := sql.Open("sqlite", ":memory:")
+        require.NoError(t, err)
+        defer db.Close()
 
-	err = createTestSchema(db)
-	require.NoError(t, err)
+        err = createTestSchema(db)
+        require.NoError(t, err)
 
-	queries := database.New(db)
+        queries := database.New(db)
 
-	source := Source{
-		Name:     "Integration Test Source",
-		URL:      server.URL,
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Integration Test Source",
+                URL:      server.URL,
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	cfg := testutil.TestConfig()
-	ctx := context.Background()
-	stored, err := FetchAndStore(ctx, queries, source, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, 1, stored)
+        cfg := testutil.TestConfig()
+        ctx := context.Background()
+        stored, err := FetchAndStore(ctx, queries, source, cfg, FetchOptions{})
+        require.NoError(t, err)
+        assert.Equal(t, 1, stored)
 
-	dbArticles, err := queries.ListArticles(ctx)
-	require.NoError(t, err)
-	assert.Len(t, dbArticles, 1)
-	assert.Equal(t, "Integration Test Article", dbArticles[0].Title.String)
-	assert.Equal(t, "https://example.com/integration", dbArticles[0].Url.String)
-	assert.Equal(t, "Integration Test Source", dbArticles[0].SourceName.String)
+        dbArticles, err := queries.ListArticles(ctx)
+        require.NoError(t, err)
+        assert.Len(t, dbArticles, 1)
+        assert.Equal(t, "Integration Test Article", dbArticles[0].Title.String)
+        assert.Equal(t, "https://example.com/integration", dbArticles[0].Url.String)
+        assert.Equal(t, "Integration Test Source", dbArticles[0].SourceName.String)
 }
 
 func createTestSchema(db *sql.DB) error {
-	schema := `CREATE TABLE IF NOT EXISTS articles (
+        schema := `CREATE TABLE IF NOT EXISTS articles (
                 id INTEGER PRIMARY KEY,
                 title TEXT,
                 url TEXT UNIQUE,
@@ -192,6 +192,6 @@ func createTestSchema(db *sql.DB) error {
                 story_group_id TEXT
         );`
 
-	_, err := db.Exec(schema)
-	return err
+        _, err := db.Exec(schema)
+        return err
 }

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -1,19 +1,19 @@
 package fetcher
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+        "context"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
 
-	"github.com/robertguss/ai-news-agent-cli/internal/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+        "github.com/robertguss/ai-news-agent-cli/internal/testutil"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
 )
 
 func TestFetch_Success(t *testing.T) {
-	rssContent := `<?xml version="1.0" encoding="UTF-8"?>
+        rssContent := `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
     <channel>
         <title>Test Feed</title>
@@ -34,119 +34,119 @@ func TestFetch_Success(t *testing.T) {
     </channel>
 </rss>`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/rss+xml")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(rssContent))
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "application/rss+xml")
+                w.WriteHeader(http.StatusOK)
+                _, _ = w.Write([]byte(rssContent))
+        }))
+        defer server.Close()
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      server.URL,
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      server.URL,
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	cfg := testutil.TestConfig()
-	ctx := context.Background()
-	opts := FetchOptions{Limit: 0}
-	articles, err := Fetch(ctx, source, cfg, opts)
+        cfg := testutil.TestConfig()
+        ctx := context.Background()
+        opts := FetchOptions{Limit: 0}
+        articles, err := Fetch(ctx, source, cfg, opts)
 
-	require.NoError(t, err)
-	require.Len(t, articles, 2)
+        require.NoError(t, err)
+        require.Len(t, articles, 2)
 
-	assert.Equal(t, "Test Article 1", articles[0].Title)
-	assert.Equal(t, "https://example.com/article1", articles[0].Link)
-	assert.False(t, articles[0].PublishedDate.IsZero())
+        assert.Equal(t, "Test Article 1", articles[0].Title)
+        assert.Equal(t, "https://example.com/article1", articles[0].Link)
+        assert.False(t, articles[0].PublishedDate.IsZero())
 
-	assert.Equal(t, "Test Article 2", articles[1].Title)
-	assert.Equal(t, "https://example.com/article2", articles[1].Link)
-	assert.False(t, articles[1].PublishedDate.IsZero())
+        assert.Equal(t, "Test Article 2", articles[1].Title)
+        assert.Equal(t, "https://example.com/article2", articles[1].Link)
+        assert.False(t, articles[1].PublishedDate.IsZero())
 }
 
 func TestFetch_NetworkError(t *testing.T) {
-	source := Source{
-		Name:     "Test Source",
-		URL:      "http://nonexistent-domain-12345.com/feed.xml",
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      "http://nonexistent-domain-12345.com/feed.xml",
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
 
-	cfg := testutil.TestConfig()
-	articles, err := Fetch(ctx, source, cfg)
+        cfg := testutil.TestConfig()
+        articles, err := Fetch(ctx, source, cfg, FetchOptions{})
 
-	assert.Error(t, err)
-	assert.Nil(t, articles)
+        assert.Error(t, err)
+        assert.Nil(t, articles)
 }
 
 func TestFetch_InvalidRSS(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("<html><body>Not RSS</body></html>"))
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "text/html")
+                w.WriteHeader(http.StatusOK)
+                _, _ = w.Write([]byte("<html><body>Not RSS</body></html>"))
+        }))
+        defer server.Close()
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      server.URL,
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      server.URL,
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	ctx := context.Background()
-	cfg := testutil.TestConfig()
-	articles, err := Fetch(ctx, source, cfg)
+        ctx := context.Background()
+        cfg := testutil.TestConfig()
+        articles, err := Fetch(ctx, source, cfg, FetchOptions{})
 
-	assert.Error(t, err)
-	assert.Nil(t, articles)
+        assert.Error(t, err)
+        assert.Nil(t, articles)
 }
 
 func TestFetch_HTTPError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                w.WriteHeader(http.StatusNotFound)
+        }))
+        defer server.Close()
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      server.URL,
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      server.URL,
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	ctx := context.Background()
-	cfg := testutil.TestConfig()
-	articles, err := Fetch(ctx, source, cfg)
+        ctx := context.Background()
+        cfg := testutil.TestConfig()
+        articles, err := Fetch(ctx, source, cfg, FetchOptions{})
 
-	assert.Error(t, err)
-	assert.Nil(t, articles)
+        assert.Error(t, err)
+        assert.Nil(t, articles)
 }
 
 func TestFetch_ContextTimeout(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+        server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                time.Sleep(2 * time.Second)
+                w.WriteHeader(http.StatusOK)
+        }))
+        defer server.Close()
 
-	source := Source{
-		Name:     "Test Source",
-		URL:      server.URL,
-		Type:     "rss",
-		Priority: 1,
-	}
+        source := Source{
+                Name:     "Test Source",
+                URL:      server.URL,
+                Type:     "rss",
+                Priority: 1,
+        }
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+        ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+        defer cancel()
 
-	cfg := testutil.TestConfig()
-	articles, err := Fetch(ctx, source, cfg)
+        cfg := testutil.TestConfig()
+        articles, err := Fetch(ctx, source, cfg, FetchOptions{})
 
-	assert.Error(t, err)
-	assert.Nil(t, articles)
+        assert.Error(t, err)
+        assert.Nil(t, articles)
 }

--- a/internal/tui/viewui/model.go
+++ b/internal/tui/viewui/model.go
@@ -1,537 +1,537 @@
 package viewui
 
 import (
-	"fmt"
-	"os/exec"
-	"runtime"
-	"strings"
+        "fmt"
+        "os/exec"
+        "runtime"
+        "strings"
 
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+        "github.com/charmbracelet/bubbles/textinput"
+        tea "github.com/charmbracelet/bubbletea"
+        "github.com/charmbracelet/lipgloss"
 )
 
 type ArticleItem struct {
-	ID      int64
-	Title   string
-	Source  string
-	Summary string
-	URL     string
-	IsRead  bool
+        ID      int64
+        Title   string
+        Source  string
+        Summary string
+        URL     string
+        IsRead  bool
 }
 
 type FilterMode int
 
 const (
-	FilterNone FilterMode = iota
-	FilterSearch
-	FilterSource
-	FilterReadStatus
+        FilterNone FilterMode = iota
+        FilterSearch
+        FilterSource
+        FilterReadStatus
 )
 
 type ReadStatusFilter int
 
 const (
-	ShowAll ReadStatusFilter = iota
-	ShowUnread
-	ShowRead
+        ShowAll ReadStatusFilter = iota
+        ShowUnread
+        ShowRead
 )
 
 type Model struct {
-	articles         []ArticleItem
-	filteredArticles []ArticleItem
-	selectedIndex    int
-	width            int
-	height           int
-	markReadFunc     func(int64) error
-	toggleReadFunc   func(int64) error
+        articles         []ArticleItem
+        filteredArticles []ArticleItem
+        selectedIndex    int
+        width            int
+        height           int
+        markReadFunc     func(int64) error
+        toggleReadFunc   func(int64) error
 
-	// Filtering
-	filterMode       FilterMode
-	searchInput      textinput.Model
-	sourceFilter     string
-	availableSources []string
-	sourceIndex      int
-	readStatusFilter ReadStatusFilter
+        // Filtering
+        filterMode       FilterMode
+        searchInput      textinput.Model
+        sourceFilter     string
+        availableSources []string
+        sourceIndex      int
+        readStatusFilter ReadStatusFilter
 }
 
 var (
-	selectedStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#874BFD")).
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Bold(true)
+        selectedStyle = lipgloss.NewStyle().
+                        Background(lipgloss.Color("#874BFD")).
+                        Foreground(lipgloss.Color("#FFFFFF")).
+                        Bold(true)
 
-	unreadStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00FF87")).
-			Bold(true)
+        unreadStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#00FF87")).
+                        Bold(true)
 
-	readStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#7D7D7D"))
+        readStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#7D7D7D"))
 
-	previewStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#874BFD")).
-			Padding(1).
-			Height(10)
+        previewStyle = lipgloss.NewStyle().
+                        Border(lipgloss.RoundedBorder()).
+                        BorderForeground(lipgloss.Color("#874BFD")).
+                        Padding(1).
+                        Height(10)
 
-	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#7D7D7D")).
-			Italic(true)
+        helpStyle = lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("#7D7D7D")).
+                        Italic(true)
 )
 
 func New(articles []ArticleItem) Model {
-	searchInput := textinput.New()
-	searchInput.Placeholder = "Search articles..."
-	searchInput.CharLimit = 50
+        searchInput := textinput.New()
+        searchInput.Placeholder = "Search articles..."
+        searchInput.CharLimit = 50
 
-	model := Model{
-		articles:         articles,
-		filteredArticles: articles,
-		selectedIndex:    0,
-		filterMode:       FilterNone,
-		searchInput:      searchInput,
-		readStatusFilter: ShowAll,
-	}
+        model := Model{
+                articles:         articles,
+                filteredArticles: articles,
+                selectedIndex:    0,
+                filterMode:       FilterNone,
+                searchInput:      searchInput,
+                readStatusFilter: ShowAll,
+        }
 
-	// Extract unique sources
-	sourceMap := make(map[string]bool)
-	for _, article := range articles {
-		sourceMap[article.Source] = true
-	}
+        // Extract unique sources
+        sourceMap := make(map[string]bool)
+        for _, article := range articles {
+                sourceMap[article.Source] = true
+        }
 
-	model.availableSources = []string{"All Sources"}
-	for source := range sourceMap {
-		model.availableSources = append(model.availableSources, source)
-	}
+        model.availableSources = []string{"All Sources"}
+        for source := range sourceMap {
+                model.availableSources = append(model.availableSources, source)
+        }
 
-	return model
+        return model
 }
 
 func (m *Model) SetCallbacks(markRead, toggleRead func(int64) error) {
-	m.markReadFunc = markRead
-	m.toggleReadFunc = toggleRead
+        m.markReadFunc = markRead
+        m.toggleReadFunc = toggleRead
 }
 
 func (m Model) Init() tea.Cmd {
-	return nil
+        return nil
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
+        var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
+        switch msg := msg.(type) {
+        case tea.WindowSizeMsg:
+                m.width = msg.Width
+                m.height = msg.Height
 
-	case tea.KeyMsg:
-		// Handle filter mode specific keys
-		if m.filterMode == FilterSearch {
-			switch msg.String() {
-			case "esc":
-				m.filterMode = FilterNone
-				m.searchInput.Blur()
-				m.applyFilters()
-			case "enter":
-				m.filterMode = FilterNone
-				m.searchInput.Blur()
-				m.applyFilters()
-			default:
-				m.searchInput, cmd = m.searchInput.Update(msg)
-				m.applyFilters()
-				return m, cmd
-			}
-		} else {
-			// Normal navigation and commands
-			switch msg.String() {
-			case "q", "ctrl+c":
-				return m, tea.Quit
+        case tea.KeyMsg:
+                // Handle filter mode specific keys
+                if m.filterMode == FilterSearch {
+                        switch msg.String() {
+                        case "esc":
+                                m.filterMode = FilterNone
+                                m.searchInput.Blur()
+                                m.applyFilters()
+                        case "enter":
+                                m.filterMode = FilterNone
+                                m.searchInput.Blur()
+                                m.applyFilters()
+                        default:
+                                m.searchInput, cmd = m.searchInput.Update(msg)
+                                m.applyFilters()
+                                return m, cmd
+                        }
+                } else {
+                        // Normal navigation and commands
+                        switch msg.String() {
+                        case "q", "ctrl+c":
+                                return m, tea.Quit
 
-			case "up", "k":
-				if m.selectedIndex > 0 {
-					m.selectedIndex--
-				}
+                        case "up", "k":
+                                if m.selectedIndex > 0 {
+                                        m.selectedIndex--
+                                }
 
-			case "down", "j":
-				if m.selectedIndex < len(m.filteredArticles)-1 {
-					m.selectedIndex++
-				}
+                        case "down", "j":
+                                if m.selectedIndex < len(m.filteredArticles)-1 {
+                                        m.selectedIndex++
+                                }
 
-			case "enter":
-				if len(m.filteredArticles) > 0 && m.markReadFunc != nil {
-					article := m.getSelectedArticle()
-					if article != nil && !article.IsRead {
-						err := m.markReadFunc(article.ID)
-						if err == nil {
-							article.IsRead = true
-							m.applyFilters()
-						}
-					}
-				}
+                        case "enter":
+                                if len(m.filteredArticles) > 0 && m.markReadFunc != nil {
+                                        article := m.getSelectedArticle()
+                                        if article != nil && !article.IsRead {
+                                                err := m.markReadFunc(article.ID)
+                                                if err == nil {
+                                                        article.IsRead = true
+                                                        m.applyFilters()
+                                                }
+                                        }
+                                }
 
-			case " ": // Space key
-				if len(m.filteredArticles) > 0 {
-					article := m.getSelectedArticle()
-					if article != nil {
-						if m.markReadFunc != nil && !article.IsRead {
-							err := m.markReadFunc(article.ID)
-							if err == nil {
-								article.IsRead = true
-								m.applyFilters()
-							}
-						}
-						// Open in browser
-						go openBrowser(article.URL)
-					}
-				}
+                        case " ": // Space key
+                                if len(m.filteredArticles) > 0 {
+                                        article := m.getSelectedArticle()
+                                        if article != nil {
+                                                if m.markReadFunc != nil && !article.IsRead {
+                                                        err := m.markReadFunc(article.ID)
+                                                        if err == nil {
+                                                                article.IsRead = true
+                                                                m.applyFilters()
+                                                        }
+                                                }
+                                                // Open in browser
+                                                go func() { _ = openBrowser(article.URL) }()
+                                        }
+                                }
 
-			case "r":
-				if len(m.filteredArticles) > 0 && m.toggleReadFunc != nil {
-					article := m.getSelectedArticle()
-					if article != nil {
-						err := m.toggleReadFunc(article.ID)
-						if err == nil {
-							article.IsRead = !article.IsRead
-							m.applyFilters()
-						}
-					}
-				}
+                        case "r":
+                                if len(m.filteredArticles) > 0 && m.toggleReadFunc != nil {
+                                        article := m.getSelectedArticle()
+                                        if article != nil {
+                                                err := m.toggleReadFunc(article.ID)
+                                                if err == nil {
+                                                        article.IsRead = !article.IsRead
+                                                        m.applyFilters()
+                                                }
+                                        }
+                                }
 
-			case "/":
-				m.filterMode = FilterSearch
-				m.searchInput.Focus()
-				return m, textinput.Blink
+                        case "/":
+                                m.filterMode = FilterSearch
+                                m.searchInput.Focus()
+                                return m, textinput.Blink
 
-			case "s":
-				m.cycleSourceFilter()
-				m.applyFilters()
+                        case "s":
+                                m.cycleSourceFilter()
+                                m.applyFilters()
 
-			case "f":
-				m.cycleReadStatusFilter()
-				m.applyFilters()
+                        case "f":
+                                m.cycleReadStatusFilter()
+                                m.applyFilters()
 
-			case "esc":
-				m.clearFilters()
-				m.applyFilters()
-			}
-		}
-	}
-	return m, cmd
+                        case "esc":
+                                m.clearFilters()
+                                m.applyFilters()
+                        }
+                }
+        }
+        return m, cmd
 }
 
 func (m Model) View() string {
-	if len(m.articles) == 0 {
-		return "No articles found.\n\nPress 'q' to quit"
-	}
+        if len(m.articles) == 0 {
+                return "No articles found.\n\nPress 'q' to quit"
+        }
 
-	// Show search input if in search mode
-	if m.filterMode == FilterSearch {
-		searchView := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#874BFD")).
-			Padding(0, 1).
-			Render("Search: " + m.searchInput.View())
+        // Show search input if in search mode
+        if m.filterMode == FilterSearch {
+                searchView := lipgloss.NewStyle().
+                        Border(lipgloss.RoundedBorder()).
+                        BorderForeground(lipgloss.Color("#874BFD")).
+                        Padding(0, 1).
+                        Render("Search: " + m.searchInput.View())
 
-		return searchView + "\n\nPress Enter to apply, Esc to cancel"
-	}
+                return searchView + "\n\nPress Enter to apply, Esc to cancel"
+        }
 
-	if len(m.filteredArticles) == 0 {
-		return "No articles match current filters.\n\nPress 'esc' to clear filters, 'q' to quit"
-	}
+        if len(m.filteredArticles) == 0 {
+                return "No articles match current filters.\n\nPress 'esc' to clear filters, 'q' to quit"
+        }
 
-	// Calculate layout dimensions (50/50 split)
-	listWidth := m.width / 2
-	previewWidth := m.width - listWidth - 2 // Account for border
+        // Calculate layout dimensions (50/50 split)
+        listWidth := m.width / 2
+        previewWidth := m.width - listWidth - 2 // Account for border
 
-	if listWidth < 20 {
-		listWidth = 20
-	}
-	if previewWidth < 20 {
-		previewWidth = 20
-	}
+        if listWidth < 20 {
+                listWidth = 20
+        }
+        if previewWidth < 20 {
+                previewWidth = 20
+        }
 
-	// Build article list (left pane)
-	listPane := m.renderArticleList(listWidth)
+        // Build article list (left pane)
+        listPane := m.renderArticleList(listWidth)
 
-	// Build preview pane (right pane)
-	previewPane := m.renderPreview(previewWidth)
+        // Build preview pane (right pane)
+        previewPane := m.renderPreview(previewWidth)
 
-	// Combine panes side by side
-	return lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane)
+        // Combine panes side by side
+        return lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane)
 }
 
 func (m Model) renderArticleList(width int) string {
-	var b strings.Builder
+        var b strings.Builder
 
-	// Title with filter info
-	title := fmt.Sprintf("Articles (%d/%d shown, %d unread)",
-		len(m.filteredArticles), len(m.articles), m.countUnread())
-	b.WriteString(lipgloss.NewStyle().Bold(true).Render(title) + "\n")
+        // Title with filter info
+        title := fmt.Sprintf("Articles (%d/%d shown, %d unread)",
+                len(m.filteredArticles), len(m.articles), m.countUnread())
+        b.WriteString(lipgloss.NewStyle().Bold(true).Render(title) + "\n")
 
-	// Filter status
-	filterInfo := m.getFilterInfo()
-	if filterInfo != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#00D7FF")).Render(filterInfo) + "\n")
-	}
-	b.WriteString("\n")
+        // Filter status
+        filterInfo := m.getFilterInfo()
+        if filterInfo != "" {
+                b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#00D7FF")).Render(filterInfo) + "\n")
+        }
+        b.WriteString("\n")
 
-	for i, article := range m.filteredArticles {
-		var style lipgloss.Style
-		prefix := "  "
+        for i, article := range m.filteredArticles {
+                var style lipgloss.Style
+                prefix := "  "
 
-		if i == m.selectedIndex {
-			style = selectedStyle
-			prefix = "> "
-		} else if article.IsRead {
-			style = readStyle
-		} else {
-			style = unreadStyle
-			prefix = "● "
-		}
+                if i == m.selectedIndex {
+                        style = selectedStyle
+                        prefix = "> "
+                } else if article.IsRead {
+                        style = readStyle
+                } else {
+                        style = unreadStyle
+                        prefix = "● "
+                }
 
-		status := ""
-		if article.IsRead {
-			status = "[READ] "
-		} else {
-			status = "[NEW] "
-		}
+                status := ""
+                if article.IsRead {
+                        status = "[READ] "
+                } else {
+                        status = "[NEW] "
+                }
 
-		line := fmt.Sprintf("%s%s%s", prefix, status, article.Title)
-		if len(line) > width-4 {
-			line = line[:width-7] + "..."
-		}
+                line := fmt.Sprintf("%s%s%s", prefix, status, article.Title)
+                if len(line) > width-4 {
+                        line = line[:width-7] + "..."
+                }
 
-		b.WriteString(style.Render(line) + "\n")
+                b.WriteString(style.Render(line) + "\n")
 
-		// Add source info for selected item
-		if i == m.selectedIndex {
-			sourceLine := fmt.Sprintf("    Source: %s", article.Source)
-			if len(sourceLine) > width-4 {
-				sourceLine = sourceLine[:width-7] + "..."
-			}
-			b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#7D7D7D")).Render(sourceLine) + "\n")
-		}
-	}
+                // Add source info for selected item
+                if i == m.selectedIndex {
+                        sourceLine := fmt.Sprintf("    Source: %s", article.Source)
+                        if len(sourceLine) > width-4 {
+                                sourceLine = sourceLine[:width-7] + "..."
+                        }
+                        b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#7D7D7D")).Render(sourceLine) + "\n")
+                }
+        }
 
-	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("↑↓ navigate • Enter preview • Space open • R toggle"))
-	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("/ search • S source • F filter • ESC clear • Q quit"))
+        b.WriteString("\n")
+        b.WriteString(helpStyle.Render("↑↓ navigate • Enter preview • Space open • R toggle"))
+        b.WriteString("\n")
+        b.WriteString(helpStyle.Render("/ search • S source • F filter • ESC clear • Q quit"))
 
-	return lipgloss.NewStyle().Width(width).Render(b.String())
+        return lipgloss.NewStyle().Width(width).Render(b.String())
 }
 
 func (m Model) renderPreview(width int) string {
-	if m.selectedIndex >= len(m.filteredArticles) {
-		return previewStyle.Width(width).Render("No article selected")
-	}
+        if m.selectedIndex >= len(m.filteredArticles) {
+                return previewStyle.Width(width).Render("No article selected")
+        }
 
-	article := m.filteredArticles[m.selectedIndex]
+        article := m.filteredArticles[m.selectedIndex]
 
-	var b strings.Builder
+        var b strings.Builder
 
-	// Title
-	b.WriteString(lipgloss.NewStyle().Bold(true).Render(article.Title) + "\n\n")
+        // Title
+        b.WriteString(lipgloss.NewStyle().Bold(true).Render(article.Title) + "\n\n")
 
-	// Source and status
-	status := "Unread"
-	if article.IsRead {
-		status = "Read"
-	}
-	b.WriteString(fmt.Sprintf("Source: %s • Status: %s\n\n", article.Source, status))
+        // Source and status
+        status := "Unread"
+        if article.IsRead {
+                status = "Read"
+        }
+        b.WriteString(fmt.Sprintf("Source: %s • Status: %s\n\n", article.Source, status))
 
-	// Summary
-	if article.Summary != "" {
-		b.WriteString("Summary:\n")
-		// Word wrap the summary
-		wrapped := wordWrap(article.Summary, width-4)
-		b.WriteString(wrapped + "\n\n")
-	}
+        // Summary
+        if article.Summary != "" {
+                b.WriteString("Summary:\n")
+                // Word wrap the summary
+                wrapped := wordWrap(article.Summary, width-4)
+                b.WriteString(wrapped + "\n\n")
+        }
 
-	// URL
-	if article.URL != "" {
-		b.WriteString("URL: " + article.URL + "\n\n")
-	}
+        // URL
+        if article.URL != "" {
+                b.WriteString("URL: " + article.URL + "\n\n")
+        }
 
-	// Help text
-	b.WriteString(helpStyle.Render("Enter to mark as read • Space to open in browser"))
+        // Help text
+        b.WriteString(helpStyle.Render("Enter to mark as read • Space to open in browser"))
 
-	return previewStyle.Width(width).Render(b.String())
+        return previewStyle.Width(width).Render(b.String())
 }
 
 func (m Model) countUnread() int {
-	count := 0
-	for _, article := range m.articles {
-		if !article.IsRead {
-			count++
-		}
-	}
-	return count
+        count := 0
+        for _, article := range m.articles {
+                if !article.IsRead {
+                        count++
+                }
+        }
+        return count
 }
 
 func (m *Model) getSelectedArticle() *ArticleItem {
-	if m.selectedIndex >= len(m.filteredArticles) {
-		return nil
-	}
+        if m.selectedIndex >= len(m.filteredArticles) {
+                return nil
+        }
 
-	// Find the article in the original slice to modify it
-	selectedArticle := &m.filteredArticles[m.selectedIndex]
-	for i := range m.articles {
-		if m.articles[i].ID == selectedArticle.ID {
-			return &m.articles[i]
-		}
-	}
-	return nil
+        // Find the article in the original slice to modify it
+        selectedArticle := &m.filteredArticles[m.selectedIndex]
+        for i := range m.articles {
+                if m.articles[i].ID == selectedArticle.ID {
+                        return &m.articles[i]
+                }
+        }
+        return nil
 }
 
 func (m *Model) applyFilters() {
-	m.filteredArticles = nil
+        m.filteredArticles = nil
 
-	for _, article := range m.articles {
-		if m.matchesFilters(article) {
-			m.filteredArticles = append(m.filteredArticles, article)
-		}
-	}
+        for _, article := range m.articles {
+                if m.matchesFilters(article) {
+                        m.filteredArticles = append(m.filteredArticles, article)
+                }
+        }
 
-	// Adjust selected index if needed
-	if m.selectedIndex >= len(m.filteredArticles) {
-		m.selectedIndex = len(m.filteredArticles) - 1
-	}
-	if m.selectedIndex < 0 {
-		m.selectedIndex = 0
-	}
+        // Adjust selected index if needed
+        if m.selectedIndex >= len(m.filteredArticles) {
+                m.selectedIndex = len(m.filteredArticles) - 1
+        }
+        if m.selectedIndex < 0 {
+                m.selectedIndex = 0
+        }
 }
 
 func (m Model) matchesFilters(article ArticleItem) bool {
-	// Search filter
-	searchTerm := strings.ToLower(m.searchInput.Value())
-	if searchTerm != "" {
-		titleMatch := strings.Contains(strings.ToLower(article.Title), searchTerm)
-		summaryMatch := strings.Contains(strings.ToLower(article.Summary), searchTerm)
-		if !titleMatch && !summaryMatch {
-			return false
-		}
-	}
+        // Search filter
+        searchTerm := strings.ToLower(m.searchInput.Value())
+        if searchTerm != "" {
+                titleMatch := strings.Contains(strings.ToLower(article.Title), searchTerm)
+                summaryMatch := strings.Contains(strings.ToLower(article.Summary), searchTerm)
+                if !titleMatch && !summaryMatch {
+                        return false
+                }
+        }
 
-	// Source filter
-	if m.sourceFilter != "" && m.sourceFilter != "All Sources" {
-		if article.Source != m.sourceFilter {
-			return false
-		}
-	}
+        // Source filter
+        if m.sourceFilter != "" && m.sourceFilter != "All Sources" {
+                if article.Source != m.sourceFilter {
+                        return false
+                }
+        }
 
-	// Read status filter
-	switch m.readStatusFilter {
-	case ShowUnread:
-		if article.IsRead {
-			return false
-		}
-	case ShowRead:
-		if !article.IsRead {
-			return false
-		}
-	}
+        // Read status filter
+        switch m.readStatusFilter {
+        case ShowUnread:
+                if article.IsRead {
+                        return false
+                }
+        case ShowRead:
+                if !article.IsRead {
+                        return false
+                }
+        }
 
-	return true
+        return true
 }
 
 func (m *Model) cycleSourceFilter() {
-	m.sourceIndex = (m.sourceIndex + 1) % len(m.availableSources)
-	m.sourceFilter = m.availableSources[m.sourceIndex]
+        m.sourceIndex = (m.sourceIndex + 1) % len(m.availableSources)
+        m.sourceFilter = m.availableSources[m.sourceIndex]
 }
 
 func (m *Model) cycleReadStatusFilter() {
-	switch m.readStatusFilter {
-	case ShowAll:
-		m.readStatusFilter = ShowUnread
-	case ShowUnread:
-		m.readStatusFilter = ShowRead
-	case ShowRead:
-		m.readStatusFilter = ShowAll
-	}
+        switch m.readStatusFilter {
+        case ShowAll:
+                m.readStatusFilter = ShowUnread
+        case ShowUnread:
+                m.readStatusFilter = ShowRead
+        case ShowRead:
+                m.readStatusFilter = ShowAll
+        }
 }
 
 func (m *Model) clearFilters() {
-	m.searchInput.SetValue("")
-	m.sourceFilter = ""
-	m.sourceIndex = 0
-	m.readStatusFilter = ShowAll
+        m.searchInput.SetValue("")
+        m.sourceFilter = ""
+        m.sourceIndex = 0
+        m.readStatusFilter = ShowAll
 }
 
 func (m Model) getFilterInfo() string {
-	var filters []string
+        var filters []string
 
-	if m.searchInput.Value() != "" {
-		filters = append(filters, fmt.Sprintf("Search: %s", m.searchInput.Value()))
-	}
+        if m.searchInput.Value() != "" {
+                filters = append(filters, fmt.Sprintf("Search: %s", m.searchInput.Value()))
+        }
 
-	if m.sourceFilter != "" && m.sourceFilter != "All Sources" {
-		filters = append(filters, fmt.Sprintf("Source: %s", m.sourceFilter))
-	}
+        if m.sourceFilter != "" && m.sourceFilter != "All Sources" {
+                filters = append(filters, fmt.Sprintf("Source: %s", m.sourceFilter))
+        }
 
-	switch m.readStatusFilter {
-	case ShowUnread:
-		filters = append(filters, "Status: Unread only")
-	case ShowRead:
-		filters = append(filters, "Status: Read only")
-	}
+        switch m.readStatusFilter {
+        case ShowUnread:
+                filters = append(filters, "Status: Unread only")
+        case ShowRead:
+                filters = append(filters, "Status: Read only")
+        }
 
-	if len(filters) == 0 {
-		return ""
-	}
+        if len(filters) == 0 {
+                return ""
+        }
 
-	return "Filters: " + strings.Join(filters, " • ")
+        return "Filters: " + strings.Join(filters, " • ")
 }
 
 func wordWrap(text string, width int) string {
-	if len(text) <= width {
-		return text
-	}
+        if len(text) <= width {
+                return text
+        }
 
-	words := strings.Fields(text)
-	if len(words) == 0 {
-		return text
-	}
+        words := strings.Fields(text)
+        if len(words) == 0 {
+                return text
+        }
 
-	var lines []string
-	var currentLine strings.Builder
+        var lines []string
+        var currentLine strings.Builder
 
-	for _, word := range words {
-		if currentLine.Len() == 0 {
-			currentLine.WriteString(word)
-		} else if currentLine.Len()+1+len(word) <= width {
-			currentLine.WriteString(" " + word)
-		} else {
-			lines = append(lines, currentLine.String())
-			currentLine.Reset()
-			currentLine.WriteString(word)
-		}
-	}
+        for _, word := range words {
+                if currentLine.Len() == 0 {
+                        currentLine.WriteString(word)
+                } else if currentLine.Len()+1+len(word) <= width {
+                        currentLine.WriteString(" " + word)
+                } else {
+                        lines = append(lines, currentLine.String())
+                        currentLine.Reset()
+                        currentLine.WriteString(word)
+                }
+        }
 
-	if currentLine.Len() > 0 {
-		lines = append(lines, currentLine.String())
-	}
+        if currentLine.Len() > 0 {
+                lines = append(lines, currentLine.String())
+        }
 
-	return strings.Join(lines, "\n")
+        return strings.Join(lines, "\n")
 }
 
 func openBrowser(url string) error {
-	if url == "" {
-		return fmt.Errorf("no URL provided")
-	}
+        if url == "" {
+                return fmt.Errorf("no URL provided")
+        }
 
-	var cmd *exec.Cmd
+        var cmd *exec.Cmd
 
-	switch runtime.GOOS {
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	case "darwin":
-		cmd = exec.Command("open", url)
-	default:
-		return fmt.Errorf("unsupported platform")
-	}
+        switch runtime.GOOS {
+        case "linux":
+                cmd = exec.Command("xdg-open", url)
+        case "windows":
+                cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+        case "darwin":
+                cmd = exec.Command("open", url)
+        default:
+                return fmt.Errorf("unsupported platform")
+        }
 
-	return cmd.Start()
+        return cmd.Start()
 }


### PR DESCRIPTION
## Summary

This PR fixes all lint errors found by running 'just lint'.

## Changes Made

- Remove unused variables: fetchAnd, tierStyle
- Fix always-true comparison in gemini processor test
- Apply struct literal simplification: tui.ArticleProgressMsg(msg)
- Fix unchecked error return values by adding assignments
- Fix os.Chdir errors with proper defer functions
- Fix w.Write errors in test files

## Files Modified

- cmd/fetch.go, cmd/styles.go, cmd/fetch_test.go, cmd/read_test.go
- Multiple test files across internal/ packages
- internal/tui/viewui/model.go

## Result

The 'just lint' command now passes with zero errors! The codebase is now lint-clean and follows Go best practices for error handling.

## Testing

- All lint checks pass
- No functional changes to application logic
- Only error handling and code cleanup improvements